### PR TITLE
[FEAT] Spring Security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,14 @@ repositories {
 }
 
 dependencies {
-	implementation "io.jsonwebtoken:jjwt:0.9.1"
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	// com.sun.xml.bind
+	implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
+	implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
+	// javax.xml.bind
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+	implementation "io.jsonwebtoken:jjwt:0.9.1"
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -38,6 +39,15 @@ dependencies {
 
 	// s3 setting
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// 스프링 시큐리티를 사용하기 위한 스타터 추가
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// 타임리프에서 스프링 시큐리티를 사용하기 위한 의존성 추가
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+	// 스프링 시큐리티를 테스트하기 위한 의존성 추가
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/networkingService/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/networkingService/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.umc.networkingService.config;
 
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -10,10 +12,26 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
+
+        // SecuritySecheme명
+        String jwtSchemeName = "jwtAuth";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer"));
+
         return new OpenAPI()
-                .components(new Components())
+                .addSecurityItem(securityRequirement)
+                .components(components)
                 .info(apiInfo());
+
     }
+
+
 
     private Info apiInfo() {
         return new Info()

--- a/src/main/java/com/umc/networkingService/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/networkingService/config/security/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.umc.networkingService.config.security;
+
+import com.umc.networkingService.config.security.auth.CustomAccessDeniedHandler;
+import com.umc.networkingService.config.security.jwt.JwtAuthenticationFilter;
+import com.umc.networkingService.config.security.jwt.JwtExceptionFilter;
+import com.umc.networkingService.config.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((authorizeRequests) ->
+                        authorizeRequests
+                                .requestMatchers("/member/**").hasAnyRole("MEMBER", "STAFF", "CENTERSTAFF", "BRANCHSTAFF", "CAMPUSSTAFF", "ADMIN")
+                                .requestMatchers("/staff/**").hasAnyRole("STAFF", "CENTERSTAFF", "BRANCHSTAFF", "CAMPUSSTAFF", "ADMIN")
+                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .anyRequest().permitAll()
+                )
+                .exceptionHandling((exceptionConfig) ->
+                        exceptionConfig.accessDeniedHandler(customAccessDeniedHandler))
+                .addFilterBefore(new JwtExceptionFilter(),
+                        JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/umc/networkingService/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/networkingService/config/security/SecurityConfig.java
@@ -34,7 +34,6 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
-                                .requestMatchers("/member/**").hasAnyRole("MEMBER", "STAFF", "CENTERSTAFF", "BRANCHSTAFF", "CAMPUSSTAFF", "ADMIN")
                                 .requestMatchers("/staff/**").hasAnyRole("STAFF", "CENTERSTAFF", "BRANCHSTAFF", "CAMPUSSTAFF", "ADMIN")
                                 .requestMatchers("/admin/**").hasRole("ADMIN")
                                 .anyRequest().permitAll()

--- a/src/main/java/com/umc/networkingService/config/security/auth/CurrentMember.java
+++ b/src/main/java/com/umc/networkingService/config/security/auth/CurrentMember.java
@@ -1,0 +1,14 @@
+package com.umc.networkingService.config.security.auth;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : member")
+public @interface CurrentMember {
+}

--- a/src/main/java/com/umc/networkingService/config/security/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/umc/networkingService/config/security/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.umc.networkingService.config.security.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        if (accessDeniedException != null) {
+            request.getRequestDispatcher("/access/denied").forward(request, response);
+        }
+    }
+}

--- a/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetails.java
+++ b/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetails.java
@@ -1,0 +1,65 @@
+package com.umc.networkingService.config.security.auth;
+
+import com.umc.networkingService.domain.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+public class PrincipalDetails implements UserDetails {
+    private Member member;
+
+    public PrincipalDetails(Member member) {
+        this.member = member;
+    }
+
+    public BCryptPasswordEncoder encodePwd() {
+        return new BCryptPasswordEncoder();
+    }
+
+    public Member getMember() {
+        return this.member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return encodePwd().encode("this is password");
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !member.isStatus();
+    }
+}
+

--- a/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetails.java
+++ b/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetails.java
@@ -39,7 +39,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getEmail();
+        return member.getClientId();
     }
 
     @Override
@@ -59,7 +59,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return !member.isStatus();
+        return member.getDeletedAt() == null;
     }
 }
 

--- a/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetailsService.java
@@ -1,0 +1,25 @@
+package com.umc.networkingService.config.security.auth;
+
+import com.umc.networkingService.domain.member.entity.Member;
+import com.umc.networkingService.domain.member.repository.MemberRepository;
+import com.umc.networkingService.global.common.exception.ErrorCode;
+import com.umc.networkingService.global.common.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public PrincipalDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member memberEntity = memberRepository.findByIdWithStatus(Long.parseLong(username))
+                .orElseThrow(() -> new RestApiException(ErrorCode.EMPTY_MEMBER));
+        return new PrincipalDetails(memberEntity);
+    }
+}

--- a/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/umc/networkingService/config/security/auth/PrincipalDetailsService.java
@@ -4,6 +4,7 @@ import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.repository.MemberRepository;
 import com.umc.networkingService.global.common.exception.ErrorCode;
 import com.umc.networkingService.global.common.exception.RestApiException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -18,7 +19,7 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public PrincipalDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member memberEntity = memberRepository.findByIdWithStatus(Long.parseLong(username))
+        Member memberEntity = memberRepository.findById(UUID.fromString(username))
                 .orElseThrow(() -> new RestApiException(ErrorCode.EMPTY_MEMBER));
         return new PrincipalDetails(memberEntity);
     }

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtAuthenticationFilter.java
@@ -24,7 +24,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         String refreshToken = jwtTokenProvider.resolveRefreshToken((HttpServletRequest) request);
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
         if (refreshToken != null && ((HttpServletRequest) request).getRequestURI()
-                .equals("/member/refresh") && jwtTokenProvider.validateRefreshToken(refreshToken)) {
+                .equals("/members/refresh") && jwtTokenProvider.validateRefreshToken(refreshToken)) {
             Authentication authentication = jwtTokenProvider.getRefreshAuthentication(refreshToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } else if (token != null && jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package com.umc.networkingService.config.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        // refresh Token이 있다면 refresh Token 사용
+        String refreshToken = jwtTokenProvider.resolveRefreshToken((HttpServletRequest) request);
+        String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
+        if (refreshToken != null && ((HttpServletRequest) request).getRequestURI()
+                .equals("/member/refresh") && jwtTokenProvider.validateRefreshToken(refreshToken)) {
+            Authentication authentication = jwtTokenProvider.getRefreshAuthentication(refreshToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtExceptionFilter.java
@@ -30,7 +30,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     public void setErrorResponse(HttpServletResponse res, RestApiException exception)
             throws IOException {
         res.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        res.setStatus(exception.getStatus().value());
+        // 수정 필요(ErrorCode 리팩토링 후 수정)
+//        res.setStatus(exception.getStatus().value());
         final Map<String, Object> body = new HashMap<>();
         body.put("code", exception.getErrorCode());
         body.put("message", exception.getMessage());

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,42 @@
+package com.umc.networkingService.config.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.networkingService.global.common.exception.RestApiException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response); // JwtAuthenticationFilter로 이동
+        } catch (RestApiException exception) {
+            setErrorResponse(response, exception);
+        }
+    }
+
+    public void setErrorResponse(HttpServletResponse res, RestApiException exception)
+            throws IOException {
+        res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        res.setStatus(exception.getStatus().value());
+        final Map<String, Object> body = new HashMap<>();
+        body.put("code", exception.getErrorCode());
+        body.put("message", exception.getMessage());
+        body.put("timestamp", LocalDateTime.now().toString());
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(res.getOutputStream(), body);
+    }
+}
+

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtTokenProvider.java
@@ -39,8 +39,8 @@ public class JwtTokenProvider {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String REFRESH_HEADER = "refreshToken";
-    private static final long TOKEN_VALID_TIME = 1000 * 60L * 60L * 24L;  // 유효기간 24시간
-    private static final long REF_TOKEN_VALID_TIME = 1000 * 60L * 60L * 24L * 60L;  // 유효기간 2달
+    private static final long TOKEN_VALID_TIME = 1000 * 60L * 60L;  // 유효기간 1시간
+    private static final long REF_TOKEN_VALID_TIME = 1000 * 60L * 60L * 24L * 14L;  // 유효기간 14일
 
     @PostConstruct
     protected void init() {

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,151 @@
+package com.umc.networkingService.config.security.jwt;
+
+import com.umc.networkingService.config.security.auth.PrincipalDetails;
+import com.umc.networkingService.domain.member.dto.MemberResponseDto;
+import io.jsonwebtoken.*;
+import com.umc.networkingService.config.security.auth.PrincipalDetailsService;
+import com.umc.networkingService.global.common.exception.ErrorCode;
+import com.umc.networkingService.global.common.exception.RestApiException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.jwt-key}")
+    private String jwtSecretKey;
+
+    @Value("${jwt.refresh-key}")
+    private String refreshSecretKey;
+
+    private final PrincipalDetailsService principalDetailsService;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String REFRESH_HEADER = "refreshToken";
+    private static final long TOKEN_VALID_TIME = 1000 * 60L * 60L * 24L;  // 유효기간 24시간
+    private static final long REF_TOKEN_VALID_TIME = 1000 * 60L * 60L * 24L * 60L;  // 유효기간 2달
+
+    @PostConstruct
+    protected void init() {
+        jwtSecretKey = Base64.getEncoder().encodeToString(jwtSecretKey.getBytes());
+        refreshSecretKey = Base64.getEncoder().encodeToString(refreshSecretKey.getBytes());
+    }
+
+    public String generateAccessToken(Long memberId) {
+        Claims claims = Jwts.claims();
+        claims.put("memberId", memberId);
+
+        Date now = new Date();
+        Date accessTokenExpirationTime = new Date(now.getTime() + TOKEN_VALID_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(accessTokenExpirationTime)
+                .signWith(SignatureAlgorithm.HS256, jwtSecretKey)
+                .compact();
+    }
+
+    public MemberResponseDto.TokenInfo generateToken(Long memberId) {
+        Claims claims = Jwts.claims();
+        claims.put("memberId", memberId);
+
+        Date now = new Date();
+        Date refreshTokenExpirationTime = new Date(now.getTime() + REF_TOKEN_VALID_TIME);
+
+        String accessToken = generateAccessToken(memberId);
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(refreshTokenExpirationTime)
+                .signWith(SignatureAlgorithm.HS256, refreshSecretKey)
+                .compact();
+
+        return new MemberResponseDto.TokenInfo(accessToken, refreshToken);
+    }
+
+    public Authentication getAuthentication(String token) {
+        try {
+            PrincipalDetails principalDetails = principalDetailsService.loadUserByUsername(
+                    getMemberIdByToken(token));
+            return new UsernamePasswordAuthenticationToken(principalDetails,
+                    "", principalDetails.getAuthorities());
+        } catch (UsernameNotFoundException exception) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_JWT);
+        }
+    }
+
+    public Authentication getRefreshAuthentication(String token) {
+        try {
+            PrincipalDetails principalDetails = principalDetailsService.loadUserByUsername(
+                    getMemberIdByRefreshToken(token));
+            return new UsernamePasswordAuthenticationToken(principalDetails,
+                    "", principalDetails.getAuthorities());
+        } catch (UsernameNotFoundException exception) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_JWT);
+        }
+    }
+
+    public String getMemberIdByToken(String token) {
+        return Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token).
+                getBody().get("memberId").toString();
+    }
+    public String getMemberIdByRefreshToken(String token) {
+        return Jwts.parser().setSigningKey(refreshSecretKey).parseClaimsJws(token).
+                getBody().get("memberId").toString();
+    }
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader(AUTHORIZATION_HEADER);
+    }
+
+    public String resolveRefreshToken(HttpServletRequest request) {
+        return request.getHeader(REFRESH_HEADER);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new RestApiException(ErrorCode.INVALID_JWT);
+        } catch (ExpiredJwtException e) {
+            throw new RestApiException(ErrorCode.EXPIRED_MEMBER_JWT);
+        } catch (UnsupportedJwtException | SignatureException e) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_JWT);
+        } catch (IllegalArgumentException e) {
+            throw new RestApiException(ErrorCode.EMPTY_JWT);
+        }
+    }
+    public boolean validateRefreshToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(refreshSecretKey).parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new RestApiException(ErrorCode.INVALID_JWT);
+        } catch (ExpiredJwtException e) {
+            throw new RestApiException(ErrorCode.EXPIRED_MEMBER_JWT);
+        } catch (UnsupportedJwtException | SignatureException e) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_JWT);
+        } catch (IllegalArgumentException e) {
+            throw new RestApiException(ErrorCode.EMPTY_JWT);
+        }
+    }
+}
+

--- a/src/main/java/com/umc/networkingService/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/umc/networkingService/domain/member/dto/MemberResponseDto.java
@@ -1,0 +1,17 @@
+package com.umc.networkingService.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberResponseDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class TokenInfo {
+
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/java/com/umc/networkingService/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/networkingService/domain/member/entity/Member.java
@@ -30,11 +30,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private UUID id;
 
-    @Email
-    @NotNull
-    private String email;
-
-    private boolean status = true;
+    private String clientId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "university_id")

--- a/src/main/java/com/umc/networkingService/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/networkingService/domain/member/entity/Member.java
@@ -7,6 +7,8 @@ import com.umc.networkingService.global.common.Part;
 import com.umc.networkingService.global.common.Role;
 import com.umc.networkingService.global.common.Semester;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +29,12 @@ public class Member extends BaseEntity {
     @UuidGenerator
     @Column(name = "member_id")
     private UUID id;
+
+    @Email
+    @NotNull
+    private String email;
+
+    private boolean status = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "university_id")

--- a/src/main/java/com/umc/networkingService/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/networkingService/domain/member/repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package com.umc.networkingService.domain.member.repository;
+
+import com.umc.networkingService.domain.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query(value = "select m from Member m where m.id = :memberId and m.status = true")
+    Optional<Member> findByIdWithStatus(@Param("memberId") Long memberId);
+    Optional<Member> findByEmail(String email);
+    Boolean existsByNickName(String nickName);
+    Boolean existsByEmail(String email);
+
+    Optional<Member> findByIdAndStatusIsTrue(Long id);
+
+    Member findByNickName(String nickName);
+}

--- a/src/main/java/com/umc/networkingService/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/networkingService/domain/member/repository/MemberRepository.java
@@ -2,19 +2,16 @@ package com.umc.networkingService.domain.member.repository;
 
 import com.umc.networkingService.domain.member.entity.Member;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query(value = "select m from Member m where m.id = :memberId and m.status = true")
-    Optional<Member> findByIdWithStatus(@Param("memberId") Long memberId);
-    Optional<Member> findByEmail(String email);
-    Boolean existsByNickName(String nickName);
-    Boolean existsByEmail(String email);
+    @Query(value = "select m from Member m where m.id = :memberId and m.deletedAt = null")
+    Optional<Member> findById(@Param("memberId") UUID memberId);
+    Boolean existsByNickname(String nickname);
 
-    Optional<Member> findByIdAndStatusIsTrue(Long id);
-
-    Member findByNickName(String nickName);
+    Member findByNickname(String nickname);
 }

--- a/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
@@ -22,8 +22,17 @@ public enum ErrorCode {
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "예외처리 테스트입니다."),
 
+    // Member
+    EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다."),
+
     // Auth
-    EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다.");
+    EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 없습니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다."),
+    EXPIRED_MEMBER_JWT(HttpStatus.UNAUTHORIZED, "AUTH_003", "만료된 JWT입니다."),
+    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "AUTH_004", "지원하지 않는 JWT입니다."),
+    INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_005", "유효하지 않은 ID TOKEN입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_006", "유효하지 않은 ACCESS TOKEN입니다."),
+    FAILED_SOCIAL_LOGIN(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_007", "소셜 로그인에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
@@ -20,7 +20,10 @@ public enum ErrorCode {
     _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청한 정보를 찾을 수 없습니다."),
 
     // For test
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "예외처리 테스트입니다.");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "예외처리 테스트입니다."),
+
+    // Auth
+    EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
@@ -23,16 +23,16 @@ public enum ErrorCode {
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "예외처리 테스트입니다."),
 
     // Member
-    EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다."),
+    EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER001", "존재하지 않는 사용자입니다."),
 
     // Auth
-    EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 없습니다."),
-    INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다."),
-    EXPIRED_MEMBER_JWT(HttpStatus.UNAUTHORIZED, "AUTH_003", "만료된 JWT입니다."),
-    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "AUTH_004", "지원하지 않는 JWT입니다."),
-    INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_005", "유효하지 않은 ID TOKEN입니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_006", "유효하지 않은 ACCESS TOKEN입니다."),
-    FAILED_SOCIAL_LOGIN(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_007", "소셜 로그인에 실패하였습니다.");
+    EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH001", "JWT가 없습니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH002", "유효하지 않은 JWT입니다."),
+    EXPIRED_MEMBER_JWT(HttpStatus.UNAUTHORIZED, "AUTH003", "만료된 JWT입니다."),
+    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "AUTH004", "지원하지 않는 JWT입니다."),
+    INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH005", "유효하지 않은 ID TOKEN입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AUTH006", "유효하지 않은 ACCESS TOKEN입니다."),
+    FAILED_SOCIAL_LOGIN(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH007", "소셜 로그인에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/networkingService/global/common/exception/RestApiException.java
+++ b/src/main/java/com/umc/networkingService/global/common/exception/RestApiException.java
@@ -9,6 +9,4 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public class RestApiException extends RuntimeException {
     private final ErrorCode errorCode;
-    private String message;
-    private final HttpStatus status;
 }

--- a/src/main/java/com/umc/networkingService/global/common/exception/RestApiException.java
+++ b/src/main/java/com/umc/networkingService/global/common/exception/RestApiException.java
@@ -2,10 +2,13 @@ package com.umc.networkingService.global.common.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 
 @Getter
 @AllArgsConstructor
 public class RestApiException extends RuntimeException {
     private final ErrorCode errorCode;
+    private String message;
+    private final HttpStatus status;
 }

--- a/src/test/java/com/umc/networkingService/RefreshTokenServiceIntegrationTest.java
+++ b/src/test/java/com/umc/networkingService/RefreshTokenServiceIntegrationTest.java
@@ -1,7 +1,10 @@
 package com.umc.networkingService;
 
+import com.umc.networkingService.config.security.jwt.JwtTokenProvider;
 import com.umc.networkingService.domain.member.entity.RefreshToken;
 import com.umc.networkingService.domain.member.service.RefreshTokenService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.junit.jupiter.api.Test;
@@ -15,6 +18,9 @@ public class RefreshTokenServiceIntegrationTest {
 
     @Autowired
     private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
 
     @Test
@@ -68,4 +74,40 @@ public class RefreshTokenServiceIntegrationTest {
         assertThrows(IllegalArgumentException.class, () -> refreshTokenService.findByMemberId(MEMBERID));
 
     }
+
+    @Test
+    void testGenerateAccessToken() {
+
+        final UUID MEMBERID = UUID.randomUUID();
+
+        Claims claims = Jwts.claims();
+        claims.put("memberId", MEMBERID);
+
+        String jwtToken = jwtTokenProvider.generateToken(MEMBERID).getAccessToken();
+
+        // When
+        UUID myMemberId = UUID.fromString(jwtTokenProvider.getMemberIdByToken(jwtToken));
+
+        // Then (test에서 사용되는 assertion, 조건이 참이 아니라면 테스트 실패)
+        assertEquals(MEMBERID, myMemberId);
+    }
+
+    @Test
+    void testGenerateRefreshToken() {
+
+        final UUID MEMBERID = UUID.randomUUID();
+
+        Claims claims = Jwts.claims();
+        claims.put("memberId", MEMBERID);
+
+        String refreshToken = jwtTokenProvider.generateToken(MEMBERID).getRefreshToken();
+
+        // When
+        UUID myMemberId = UUID.fromString(jwtTokenProvider.getMemberIdByRefreshToken(refreshToken));
+
+        // Then (test에서 사용되는 assertion, 조건이 참이 아니라면 테스트 실패)
+        assertEquals(MEMBERID, myMemberId);
+    }
+
+
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[v] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[v] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#15/SpringSecuritySetting -> develop

### 변경 사항
- Spring Security 설정
  - JWT 토큰 생성(memberId 저장)
  - 헤더에 Authorization으로 accessToken 설정
    - refreshToken 유효기간 14일(2주)
    - accessToken 1시간
    - 로그인
    - 토큰 유효성 검사 등… 함수들 구현하기(유효성 검사, 토큰 재발급 등…)
      유효기간 끝나면 토큰이 끝났다는 정보와 함께 토큰 생성 api 다시 호출
    - SecurityConfig 설정
      멤버가 가질 수 있는 최상위 권한만 부여
      (ex, 루나/고지민 - 중앙 안드로이드 파트장 & 가천대 회장 & PM 스터디원 -> 가장 높은 CENTERSTAFF 권한 부여)
      ```java
           .requestMatchers("/member/**").hasAnyRole("MEMBER", "STAFF", "CENTERSTAFF", "BRANCHSTAFF", "CAMPUSSTAFF", "ADMIN")
           .requestMatchers("/staff/**").hasAnyRole("STAFF", "CENTERSTAFF", "BRANCHSTAFF", "CAMPUSSTAFF", "ADMIN")
           .requestMatchers("/admin/**").hasRole("ADMIN")
      ```
- MemberResponseDto.TokenInfo 구조 
  ```java
    @Getter
    @Builder
    @AllArgsConstructor
    public static class TokenInfo {

        private String accessToken;
        private String refreshToken;
    }
  ```
- 테스트 코드 작성

### 테스트 결과
[testGenerateAccessToken]
<img width="874" alt="image" src="https://github.com/Team-UMC/UMC-Server/assets/21362256/bace93cc-ab10-4039-bffd-1875b14050f9">


[testGenerateRefreshToken]
<img width="850" alt="image" src="https://github.com/Team-UMC/UMC-Server/assets/21362256/9bb7415f-0176-47f5-91eb-83c73daf3254">


### 사용 가이드

```java
// Member Entity 생성 로직
...
MemberResponseDto.tokenInfo tokenInfo = jwtTokenProvider.generateToken(memeber.getMemberId());
...
// refreshToken을 redis에 저장하는 로직
```