### PR TITLE
[FEAT] 운영진용 멤버 관련 API 구현

### DIFF
--- a/src/main/java/com/umc/networkingService/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/networkingService/config/security/SecurityConfig.java
@@ -34,9 +34,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
+                                .requestMatchers("/v3/**", "/swagger-ui/**", "/members/login").permitAll()
                                 .requestMatchers("/staff/**").hasAnyRole("STAFF", "TOTAL_STAFF", "CENTER_STAFF", "BRANCH_STAFF", "CAMPUS_STAFF", "ADMIN")
                                 .requestMatchers("/admin/**").hasRole("ADMIN")
-                                .anyRequest().permitAll()
+                                .anyRequest().authenticated()
                 )
                 .exceptionHandling((exceptionConfig) ->
                         exceptionConfig.accessDeniedHandler(customAccessDeniedHandler))

--- a/src/main/java/com/umc/networkingService/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/networkingService/config/security/jwt/JwtAuthenticationFilter.java
@@ -42,6 +42,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                }
            }
         }
+
         chain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/umc/networkingService/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/networkingService/domain/member/controller/AuthController.java
@@ -2,7 +2,7 @@ package com.umc.networkingService.domain.member.controller;
 
 import com.umc.networkingService.config.security.auth.CurrentMember;
 import com.umc.networkingService.domain.member.dto.request.MemberSignUpRequest;
-import com.umc.networkingService.domain.member.dto.response.MemberGenerateNewAccessTokenResponse;
+import com.umc.networkingService.domain.member.dto.response.MemberGenerateTokenResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberLoginResponse;
 import com.umc.networkingService.domain.member.entity.Member;
@@ -57,8 +57,8 @@ public class AuthController {
             @ApiResponse(responseCode = "AUTH006", description = "유효하지 않는 RefreshToken일 경우 발생")
     })
     @GetMapping("/token/refresh")
-    public BaseResponse<MemberGenerateNewAccessTokenResponse> regenerateToken(@CurrentMember Member member,
-                                                                              @RequestHeader(value = "refreshToken") String refreshToken) {
+    public BaseResponse<MemberGenerateTokenResponse> regenerateToken(@CurrentMember Member member,
+                                                                     @RequestHeader(value = "refreshToken") String refreshToken) {
         return BaseResponse.onSuccess(authService.generateNewAccessToken(refreshToken, member));
     }
 

--- a/src/main/java/com/umc/networkingService/domain/member/controller/StaffMemberController.java
+++ b/src/main/java/com/umc/networkingService/domain/member/controller/StaffMemberController.java
@@ -36,9 +36,10 @@ public class StaffMemberController {
         return BaseResponse.onSuccess(memberService.updateProfile(member, memberId, request));
     }
 
-    @Operation(summary = "유저 검색 API", description = "운")
+    @Operation(summary = "유저 검색 API", description = "운영진이 [닉네임/이름] 검색어를 통해서 특정 유저를 검색하는 API입니다.")
     @ApiResponses( value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공")
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+            @ApiResponse(responseCode = "MEMBER006", description = "[닉네임/이름] 양식에 맞지 않을 경우 발생")
     })
     @GetMapping("/search")
     public BaseResponse<List<MemberSearchInfoResponse>> searchMemberInfo(@CurrentMember Member member,

--- a/src/main/java/com/umc/networkingService/domain/member/controller/StaffMemberController.java
+++ b/src/main/java/com/umc/networkingService/domain/member/controller/StaffMemberController.java
@@ -1,22 +1,36 @@
 package com.umc.networkingService.domain.member.controller;
 
-// TODO: security 문제 해결 후 개발
-//@Tag(name = "멤버 API", description = "운영진용 멤버 관련 API")
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/staff/members")
-//public class StaffMemberController {
-//    private final MemberService memberService;
-//    @Operation(summary = "유저 정보 수정 API", description = "운영진이 특정 유저의 직책, 기수, 파트를 수정하는 API입니다.")
-//    @ApiResponses( value = {
-//            @ApiResponse(responseCode = "COMMON200", description = "성공"),
-//            @ApiResponse(responseCode = "MEMBER002", description = "상위 운영진의 직책을 수정할 경우 발생"),
-//            @ApiResponse(responseCode = "MEMBER003", description = "지부, 학교 운영진이 중앙 직책을 수정할 경우 발생")
-//    })
-//    @PostMapping("/{memberId}/update")
-//    public BaseResponse<MemberIdResponse> updateProfile(@CurrentMember Member member,
-//                                                        @PathVariable UUID memberId,
-//                                                        @RequestBody MemberUpdateProfileRequest request) {
-//        return BaseResponse.onSuccess(memberService.updateProfile(member, memberId, request));
-//    }
-//}
+import com.umc.networkingService.config.security.auth.CurrentMember;
+import com.umc.networkingService.domain.member.dto.request.MemberUpdateProfileRequest;
+import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
+import com.umc.networkingService.domain.member.entity.Member;
+import com.umc.networkingService.domain.member.service.MemberService;
+import com.umc.networkingService.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "멤버 API", description = "운영진용 멤버 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/staff/members")
+public class StaffMemberController {
+    private final MemberService memberService;
+    @Operation(summary = "유저 정보 수정 API", description = "운영진이 특정 유저의 직책, 기수, 파트를 수정하는 API입니다.")
+    @ApiResponses( value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+            @ApiResponse(responseCode = "MEMBER002", description = "상위 운영진의 직책을 수정할 경우 발생"),
+            @ApiResponse(responseCode = "MEMBER003", description = "지부, 학교 운영진이 중앙 직책을 수정할 경우 발생")
+    })
+    @PostMapping("/{memberId}/update")
+    public BaseResponse<MemberIdResponse> updateProfile(@CurrentMember Member member,
+                                                        @PathVariable UUID memberId,
+                                                        @RequestBody MemberUpdateProfileRequest request) {
+        return BaseResponse.onSuccess(memberService.updateProfile(member, memberId, request));
+    }
+}

--- a/src/main/java/com/umc/networkingService/domain/member/controller/StaffMemberController.java
+++ b/src/main/java/com/umc/networkingService/domain/member/controller/StaffMemberController.java
@@ -3,6 +3,7 @@ package com.umc.networkingService.domain.member.controller;
 import com.umc.networkingService.config.security.auth.CurrentMember;
 import com.umc.networkingService.domain.member.dto.request.MemberUpdateProfileRequest;
 import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
+import com.umc.networkingService.domain.member.dto.response.MemberSearchInfoResponse;
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.service.MemberService;
 import com.umc.networkingService.global.common.base.BaseResponse;
@@ -13,9 +14,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "멤버 API", description = "운영진용 멤버 관련 API")
+@Tag(name = "운영진용 멤버 API", description = "운영진용 멤버 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/staff/members")
@@ -33,4 +35,15 @@ public class StaffMemberController {
                                                         @RequestBody MemberUpdateProfileRequest request) {
         return BaseResponse.onSuccess(memberService.updateProfile(member, memberId, request));
     }
+
+    @Operation(summary = "유저 검색 API", description = "운")
+    @ApiResponses( value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공")
+    })
+    @GetMapping("/search")
+    public BaseResponse<List<MemberSearchInfoResponse>> searchMemberInfo(@CurrentMember Member member,
+                                                                        @RequestParam String keyword) {
+        return BaseResponse.onSuccess(memberService.searchMemberInfo(member, keyword));
+    }
+
 }

--- a/src/main/java/com/umc/networkingService/domain/member/dto/SemesterPartInfo.java
+++ b/src/main/java/com/umc/networkingService/domain/member/dto/SemesterPartInfo.java
@@ -1,4 +1,4 @@
-package com.umc.networkingService.domain.member.dto.request;
+package com.umc.networkingService.domain.member.dto;
 
 import com.umc.networkingService.global.common.enums.Part;
 import com.umc.networkingService.global.common.enums.Semester;

--- a/src/main/java/com/umc/networkingService/domain/member/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/com/umc/networkingService/domain/member/dto/request/MemberSignUpRequest.java
@@ -1,5 +1,6 @@
 package com.umc.networkingService.domain.member.dto.request;
 
+import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/umc/networkingService/domain/member/dto/response/MemberGenerateTokenResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/member/dto/response/MemberGenerateTokenResponse.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class MemberGenerateNewAccessTokenResponse {
+public class MemberGenerateTokenResponse {
     private String accessToken;
 }

--- a/src/main/java/com/umc/networkingService/domain/member/dto/response/MemberInquiryProfileResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/member/dto/response/MemberInquiryProfileResponse.java
@@ -1,6 +1,6 @@
 package com.umc.networkingService.domain.member.dto.response;
 
-import com.umc.networkingService.domain.member.dto.request.SemesterPartInfo;
+import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
 import com.umc.networkingService.domain.member.entity.MemberRelation;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/umc/networkingService/domain/member/dto/response/MemberSearchInfoResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/member/dto/response/MemberSearchInfoResponse.java
@@ -1,14 +1,17 @@
-package com.umc.networkingService.domain.member.dto.request;
+package com.umc.networkingService.domain.member.dto.response;
 
 import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Builder
-public class MemberUpdateProfileRequest {
+public class MemberSearchInfoResponse {
+    private UUID memberId;
+    private String universityName;
     private List<String> campusPositions;
     private List<String> centerPositions;
     private List<SemesterPartInfo> semesterParts;

--- a/src/main/java/com/umc/networkingService/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/umc/networkingService/domain/member/mapper/MemberMapper.java
@@ -1,11 +1,8 @@
 package com.umc.networkingService.domain.member.mapper;
 
 import com.umc.networkingService.config.security.jwt.TokenInfo;
-import com.umc.networkingService.domain.member.dto.request.SemesterPartInfo;
-import com.umc.networkingService.domain.member.dto.response.MemberInquiryInfoWithPointResponse;
-import com.umc.networkingService.domain.member.dto.response.MemberInquiryPointsResponse;
-import com.umc.networkingService.domain.member.dto.response.MemberInquiryProfileResponse;
-import com.umc.networkingService.domain.member.dto.response.MemberLoginResponse;
+import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
+import com.umc.networkingService.domain.member.dto.response.*;
 import com.umc.networkingService.domain.member.entity.*;
 import com.umc.networkingService.domain.university.entity.University;
 import com.umc.networkingService.global.common.enums.Role;
@@ -85,6 +82,18 @@ public class MemberMapper {
                 .remainPoint(point)
                 .usedHistories(usedHistories)
                 .build();
+    }
+
+    public MemberSearchInfoResponse toSearchMembersResponse(Member member, List<String> campusPositions, List<String> centerPositions) {
+
+        return  MemberSearchInfoResponse.builder()
+                .memberId(member.getId())
+                .universityName(member.getUniversity().getName())
+                .campusPositions(campusPositions)
+                .centerPositions(centerPositions)
+                .semesterParts(toSemesterPartInfos(member.getSemesterParts()))
+                .build();
+
     }
 
     public SemesterPart toSemesterPart(Member member, SemesterPartInfo semesterPartInfo) {

--- a/src/main/java/com/umc/networkingService/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/networkingService/domain/member/repository/MemberRepository.java
@@ -16,4 +16,5 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     Optional<Member> findById(@Param("memberId") UUID memberId);
     Optional<Member> findByClientIdAndSocialType(String clientId, SocialType socialType);
     List<Member> findAllByUniversityOrderByContributionPointDesc(University university);
+    List<Member> findAllByNicknameAndName(String nickname, String name);
 }

--- a/src/main/java/com/umc/networkingService/domain/member/service/AuthService.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.umc.networkingService.domain.member.service;
 
 import com.umc.networkingService.domain.member.dto.request.MemberSignUpRequest;
-import com.umc.networkingService.domain.member.dto.response.MemberGenerateNewAccessTokenResponse;
+import com.umc.networkingService.domain.member.dto.response.MemberGenerateTokenResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberLoginResponse;
 import com.umc.networkingService.domain.member.entity.Member;
@@ -14,7 +14,7 @@ import java.util.UUID;
 public interface AuthService extends EntityLoader<Member, UUID> {
     MemberLoginResponse socialLogin(final String accessToken, SocialType socialType);
     MemberIdResponse signUp(Member member, MemberSignUpRequest request);
-    MemberGenerateNewAccessTokenResponse generateNewAccessToken(String refreshToken, Member member);
+    MemberGenerateTokenResponse generateNewAccessToken(String refreshToken, Member member);
     MemberIdResponse logout(Member member);
     MemberIdResponse withdrawal(Member member);
 }

--- a/src/main/java/com/umc/networkingService/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/AuthServiceImpl.java
@@ -8,7 +8,7 @@ import com.umc.networkingService.domain.member.client.GoogleMemberClient;
 import com.umc.networkingService.domain.member.client.KakaoMemberClient;
 import com.umc.networkingService.domain.member.client.NaverMemberClient;
 import com.umc.networkingService.domain.member.dto.request.MemberSignUpRequest;
-import com.umc.networkingService.domain.member.dto.response.MemberGenerateNewAccessTokenResponse;
+import com.umc.networkingService.domain.member.dto.response.MemberGenerateTokenResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberLoginResponse;
 import com.umc.networkingService.domain.member.entity.Member;
@@ -93,7 +93,7 @@ public class AuthServiceImpl implements AuthService {
     // 새로운 액세스 토큰 발급 함수
     @Override
     @Transactional
-    public MemberGenerateNewAccessTokenResponse generateNewAccessToken(String refreshToken, Member loginMember) {
+    public MemberGenerateTokenResponse generateNewAccessToken(String refreshToken, Member loginMember) {
 
         Member member = loadEntity(loginMember.getId());
 
@@ -104,7 +104,7 @@ public class AuthServiceImpl implements AuthService {
         if (!refreshToken.equals(savedRefreshToken.getRefreshToken()))
             throw new RestApiException(ErrorCode.INVALID_REFRESH_TOKEN);
 
-        return new MemberGenerateNewAccessTokenResponse(jwtTokenProvider.generateAccessToken(member.getId()));
+        return new MemberGenerateTokenResponse(jwtTokenProvider.generateAccessToken(member.getId()));
     }
 
     // 로그아웃 함수

--- a/src/main/java/com/umc/networkingService/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.global.common.base.EntityLoader;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemberService extends EntityLoader<Member, UUID> {
@@ -17,5 +18,6 @@ public interface MemberService extends EntityLoader<Member, UUID> {
     MemberInquiryInfoWithPointResponse inquiryInfoWithPoint(Member member);
     MemberInquiryGithubResponse inquiryGithubImage(Member member);
     MemberInquiryPointsResponse inquiryMemberPoints(Member member);
+    List<MemberSearchInfoResponse> searchMemberInfo(Member member, String keyword);
     Member saveEntity(Member member);
 }

--- a/src/main/java/com/umc/networkingService/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/MemberServiceImpl.java
@@ -128,6 +128,7 @@ public class MemberServiceImpl implements MemberService{
         return memberMapper.toInquiryHomeInfoResponse(member, rank);
     }
 
+    // 깃허브 인증 함수
     @Override
     @Transactional
     public MemberAuthenticateGithubResponse authenticateGithub(Member loginMember, String code) {
@@ -146,6 +147,7 @@ public class MemberServiceImpl implements MemberService{
         return new MemberAuthenticateGithubResponse(savedMember.getGitNickname());
     }
 
+    // 깃허브 잔디 이미지 조회 함수
     @Override
     public MemberInquiryGithubResponse inquiryGithubImage(Member loginMember) {
         Member member = loadEntity(loginMember.getId());
@@ -156,6 +158,7 @@ public class MemberServiceImpl implements MemberService{
         return new MemberInquiryGithubResponse("https://ghchart.rshah.org/2965FF/" + gitNickName);
     }
 
+    // 포인트 관련 멤버 정보 조회 함수
     @Override
     public MemberInquiryPointsResponse inquiryMemberPoints(Member loginMember) {
         Member member = loadEntity(loginMember.getId());
@@ -170,13 +173,19 @@ public class MemberServiceImpl implements MemberService{
         return memberMapper.toInquiryPointsResponse(member.getRemainPoint(), usedHistories);
     }
 
+    // 멤버 검색 함수(운영진용)
     @Override
-    public List<MemberSearchInfoResponse> searchMemberInfo(Member member, String keyword) {
+    public List<MemberSearchInfoResponse> searchMemberInfo(Member loginMember, String keyword) {
+        Member member = loadEntity(loginMember.getId());
 
         // keyword 양식 검증
         String[] nicknameAndName = validateKeyword(keyword);
 
-        List<Member> searchedMembers = memberRepository.findAllByNicknameAndName(nicknameAndName[0], nicknameAndName[1]);
+        // 해당 유저가 본인보다 상위 운영진인 경우 검색 대상에서 제외
+        List<Member> searchedMembers = memberRepository.findAllByNicknameAndName(nicknameAndName[0], nicknameAndName[1]).stream()
+                        .filter(searchedMember -> searchedMember.getRole().getPriority() > member.getRole().getPriority())
+                        .toList();
+
 
         return searchedMembers.stream()
                 .map(searchedMember -> memberMapper.toSearchMembersResponse(
@@ -264,7 +273,6 @@ public class MemberServiceImpl implements MemberService{
                 .map(MemberPosition::getName)
                 .toList();
     }
-
 
     @Override
     public Member saveEntity(Member member) {

--- a/src/main/java/com/umc/networkingService/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/MemberServiceImpl.java
@@ -97,7 +97,7 @@ public class MemberServiceImpl implements MemberService{
 
         Member member = loadEntity(loginMember.getId());
         // 본인 프로필 조회인 경우
-        if (memberId == null) {
+        if (memberId == null || member.getId().equals(memberId)) {
             return memberMapper.toInquiryProfileResponse(member, MemberRelation.MINE);
         }
 

--- a/src/main/java/com/umc/networkingService/domain/member/service/SemesterPartService.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/SemesterPartService.java
@@ -1,6 +1,6 @@
 package com.umc.networkingService.domain.member.service;
 
-import com.umc.networkingService.domain.member.dto.request.SemesterPartInfo;
+import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.entity.SemesterPart;
 import com.umc.networkingService.global.common.base.EntityLoader;

--- a/src/main/java/com/umc/networkingService/domain/member/service/SemesterPartServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/member/service/SemesterPartServiceImpl.java
@@ -1,6 +1,6 @@
 package com.umc.networkingService.domain.member.service;
 
-import com.umc.networkingService.domain.member.dto.request.SemesterPartInfo;
+import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.entity.SemesterPart;
 import com.umc.networkingService.domain.member.mapper.MemberMapper;

--- a/src/main/java/com/umc/networkingService/domain/test/controller/TestController.java
+++ b/src/main/java/com/umc/networkingService/domain/test/controller/TestController.java
@@ -1,17 +1,9 @@
 package com.umc.networkingService.domain.test.controller;
 
-import com.umc.networkingService.domain.branch.entity.Branch;
-import com.umc.networkingService.domain.branch.entity.BranchUniversity;
-import com.umc.networkingService.domain.branch.repository.BranchRepository;
-import com.umc.networkingService.domain.branch.repository.BranchUniversityRepository;
 import com.umc.networkingService.domain.test.dto.TestRequest;
 import com.umc.networkingService.domain.test.dto.TestResponse;
 import com.umc.networkingService.domain.test.service.TestService;
-import com.umc.networkingService.domain.university.entity.University;
-import com.umc.networkingService.domain.university.repository.UniversityRepository;
 import com.umc.networkingService.global.common.base.BaseResponse;
-import com.umc.networkingService.global.common.enums.Role;
-import com.umc.networkingService.global.common.enums.Semester;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/umc/networkingService/domain/test/controller/TestController.java
+++ b/src/main/java/com/umc/networkingService/domain/test/controller/TestController.java
@@ -27,9 +27,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/test")
 public class TestController {
     private final TestService testService;
-    private final UniversityRepository universityRepository;
-    private final BranchRepository branchRepository;
-    private final BranchUniversityRepository branchUniversityRepository;
 
     @Operation(summary = "성공적인 응답 반환 API", description = "테스트 문자열을 반환하는 API입니다.")
     @ApiResponse(responseCode = "200", description = "테스트 문자열을 성공적으로 반환")
@@ -65,28 +62,5 @@ public class TestController {
         return BaseResponse.onSuccess(TestResponse.TempTestDTO.builder()
                 .testString(request.getTestString())
                 .build());
-    }
-
-    @Operation(summary = "테스트 데이터 생성 API")
-    @PostMapping("/etc")
-    public void createMember(@RequestParam Role role) {
-        Branch branch = branchRepository.save(
-                Branch.builder()
-                        .name("가지")
-                        .description("가치 지부입니다.")
-                        .semester(Semester.FIFTH)
-                        .build());
-
-        University university = universityRepository.save(
-                University.builder()
-                        .name("인하대학교")
-                        .build());
-
-        BranchUniversity branchUniversity = branchUniversityRepository.save(
-                BranchUniversity.builder()
-                        .branch(branch)
-                        .university(university)
-                        .isActive(Boolean.TRUE)
-                        .build());
     }
 }

--- a/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/umc/networkingService/global/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     UNAUTHORIZED_UPDATE_CENTER_POSITION(HttpStatus.BAD_REQUEST, "MEMBER003", "지부, 학교 운영진은 중앙 직책을 부여할 수 없습니다."),
     EMPTY_MEMBER_UNIVERSITY(HttpStatus.CONFLICT, "MEMBER004", "소속 대학교가 존재하지 않는 사용자입니다."),
     UNAUTHENTICATED_GITHUB(HttpStatus.BAD_REQUEST, "MEMBER005", "깃허브 연동이 완료되지 않은 사용자입니다."),
+    INVALID_MEMBER_KEYWORD(HttpStatus.BAD_REQUEST, "MEMBER006", "검색어 양식[닉네임/이름]에 맞추어 작성해주세요. ex) 벡스/김준석"),
 
     // SemesterPart
     EMPTY_SEMESTER_PART(HttpStatus.BAD_REQUEST, "PART006", "존재하지 않는 기수의 파트입니다."),

--- a/src/test/java/com/umc/networkingService/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/umc/networkingService/domain/member/controller/AuthControllerTest.java
@@ -1,7 +1,7 @@
 package com.umc.networkingService.domain.member.controller;
 
 import com.umc.networkingService.domain.member.dto.request.MemberSignUpRequest;
-import com.umc.networkingService.domain.member.dto.response.MemberGenerateNewAccessTokenResponse;
+import com.umc.networkingService.domain.member.dto.response.MemberGenerateTokenResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberLoginResponse;
 import com.umc.networkingService.domain.member.entity.SemesterPart;
@@ -110,7 +110,7 @@ public class AuthControllerTest extends ControllerTestConfig {
     @Test
     public void generateNewAccessTokenTest() throws Exception {
         // given
-        MemberGenerateNewAccessTokenResponse response = new MemberGenerateNewAccessTokenResponse("newAccessToken");
+        MemberGenerateTokenResponse response = new MemberGenerateTokenResponse("newAccessToken");
 
         given(authService.generateNewAccessToken(any(), any())).willReturn(response);
         given(memberRepository.findById(any(UUID.class))).willReturn(Optional.of(member));

--- a/src/test/java/com/umc/networkingService/domain/member/controller/StaffMemberControllerTest.java
+++ b/src/test/java/com/umc/networkingService/domain/member/controller/StaffMemberControllerTest.java
@@ -1,22 +1,17 @@
 package com.umc.networkingService.domain.member.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.networkingService.config.security.jwt.JwtTokenProvider;
 import com.umc.networkingService.domain.member.dto.SemesterPartInfo;
 import com.umc.networkingService.domain.member.dto.request.MemberUpdateProfileRequest;
 import com.umc.networkingService.domain.member.dto.response.MemberIdResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberSearchInfoResponse;
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.entity.SemesterPart;
-import com.umc.networkingService.domain.member.entity.SocialType;
 import com.umc.networkingService.domain.member.mapper.MemberMapper;
-import com.umc.networkingService.domain.member.repository.MemberRepository;
 import com.umc.networkingService.domain.member.service.MemberService;
 import com.umc.networkingService.global.common.enums.Part;
 import com.umc.networkingService.global.common.enums.Role;
 import com.umc.networkingService.global.common.enums.Semester;
 import com.umc.networkingService.support.ControllerTestConfig;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +19,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,7 +27,6 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/umc/networkingService/domain/member/controller/StaffMemberControllerTest.java
+++ b/src/test/java/com/umc/networkingService/domain/member/controller/StaffMemberControllerTest.java
@@ -13,6 +13,7 @@ import com.umc.networkingService.domain.member.service.MemberService;
 import com.umc.networkingService.global.common.enums.Part;
 import com.umc.networkingService.global.common.enums.Role;
 import com.umc.networkingService.global.common.enums.Semester;
+import com.umc.networkingService.support.ControllerTestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,37 +38,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("StaffMember 컨트롤러의")
 @SpringBootTest
 @AutoConfigureMockMvc
-public class StaffMemberControllerTest {
+public class StaffMemberControllerTest extends ControllerTestConfig {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
-    @Autowired private JwtTokenProvider jwtTokenProvider;
     @Autowired private MemberMapper memberMapper;
     @MockBean private MemberService memberService;
-    @MockBean private MemberRepository memberRepository;
-
-    private Member member;
-    private String accessToken;
-
-    @BeforeEach
-    public void setUp() {
-        member = createMember();
-        setToken(member);
-    }
-
-    private Member createMember() {
-        return Member.builder()
-                .id(UUID.randomUUID())
-                .clientId("111111")
-                .socialType(SocialType.KAKAO)
-                .role(Role.MEMBER)
-                .build();
-    }
-
-    private void setToken(Member member) {
-        accessToken = jwtTokenProvider.generateAccessToken(member.getId());
-    }
-
     // 에러 해결해야함
     @DisplayName("유저 정보 수정 API 테스트")
     @Test
@@ -86,12 +60,12 @@ public class StaffMemberControllerTest {
                 .build();
 
         MemberIdResponse response = new MemberIdResponse(member.getId());
+
         given(memberService.updateProfile(any(Member.class), any(UUID.class), any(MemberUpdateProfileRequest.class))).willReturn(response);
         given(memberRepository.findById(any(UUID.class))).willReturn(Optional.of(member));
 
         // when & then
         mockMvc.perform(post("/staff/members/" + memberId + "/update")
-                        .with(user(member.getClientId())) // RequestPostProcessor를 사용하여 요청에 인증 정보 추가
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", accessToken)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/umc/networkingService/domain/member/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/umc/networkingService/domain/member/service/AuthServiceIntegrationTest.java
@@ -4,7 +4,7 @@ import com.umc.networkingService.domain.member.client.GoogleMemberClient;
 import com.umc.networkingService.domain.member.client.KakaoMemberClient;
 import com.umc.networkingService.domain.member.client.NaverMemberClient;
 import com.umc.networkingService.domain.member.dto.request.MemberSignUpRequest;
-import com.umc.networkingService.domain.member.dto.response.MemberGenerateNewAccessTokenResponse;
+import com.umc.networkingService.domain.member.dto.response.MemberGenerateTokenResponse;
 import com.umc.networkingService.domain.member.dto.response.MemberLoginResponse;
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.entity.RefreshToken;
@@ -154,7 +154,7 @@ public class AuthServiceIntegrationTest extends ServiceIntegrationTestConfig {
     @DisplayName("access 토큰 재발급 테스트")
     public void generateNewAccessTokenTest() {
         // when
-        MemberGenerateNewAccessTokenResponse response = authService.generateNewAccessToken(refreshToken, member);
+        MemberGenerateTokenResponse response = authService.generateNewAccessToken(refreshToken, member);
 
         // then
         assertNotNull(response);

--- a/src/test/java/com/umc/networkingService/domain/member/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/umc/networkingService/domain/member/service/MemberServiceIntegrationTest.java
@@ -220,7 +220,7 @@ public class MemberServiceIntegrationTest extends ServiceIntegrationTestConfig {
     @Transactional
     public void inquiryMyProfile() {
         // given
-        authService.signUp(member, getInfoRequest(member));
+        authService.signUp(member, getInfoRequest());
 
         // when
         MemberInquiryProfileResponse response = memberService.inquiryProfile(member, null);
@@ -238,7 +238,7 @@ public class MemberServiceIntegrationTest extends ServiceIntegrationTestConfig {
         // given
         Member loginMember = createMember("222222", Role.CAMPUS_STAFF);
 
-        authService.signUp(member, getInfoRequest(member));
+        authService.signUp(member, getInfoRequest());
 
         friendRepository.save(Friend.builder()
                 .sender(loginMember)
@@ -261,7 +261,7 @@ public class MemberServiceIntegrationTest extends ServiceIntegrationTestConfig {
         // given
         Member loginMember = createMember("222222", Role.CAMPUS_STAFF);
 
-        authService.signUp(member, getInfoRequest(member));
+        authService.signUp(member, getInfoRequest());
 
         // when
         MemberInquiryProfileResponse response = memberService.inquiryProfile(loginMember, member.getId());
@@ -277,20 +277,20 @@ public class MemberServiceIntegrationTest extends ServiceIntegrationTestConfig {
     @Transactional
     public void inquiryHomeInfo() {
         // given
-        authService.signUp(member, getInfoRequest(member));
+        authService.signUp(member, getInfoRequest());
         member.updateContributionPoint(1000L);
 
         Member universityMember1 = createMember("222222", Role.MEMBER);
-        authService.signUp(universityMember1, getInfoRequest(universityMember1));
+        authService.signUp(universityMember1, getInfoRequest());
         universityMember1.updateContributionPoint(2000L);
         Member universityMember2 = createMember("333333", Role.MEMBER);
-        authService.signUp(universityMember2, getInfoRequest(universityMember2));
+        authService.signUp(universityMember2, getInfoRequest());
         universityMember2.updateContributionPoint(2000L);
         Member universityMember3 = createMember("444444", Role.MEMBER);
-        authService.signUp(universityMember3, getInfoRequest(universityMember3));
+        authService.signUp(universityMember3, getInfoRequest());
         universityMember3.updateContributionPoint(3000L);
         Member universityMember4 = createMember("555555", Role.MEMBER);
-        authService.signUp(universityMember4, getInfoRequest(universityMember4));
+        authService.signUp(universityMember4, getInfoRequest());
         universityMember4.updateContributionPoint(1000L);
 
         // when
@@ -391,4 +391,66 @@ public class MemberServiceIntegrationTest extends ServiceIntegrationTestConfig {
                 .toList();
         assertEquals(List.of(10L, 5L), points);
     }
+
+    @Test
+    @DisplayName("운영진용 유저 검색 테스트")
+    @Transactional
+    public void searchMemberInfo() {
+        // given
+        String keyword = "벡스/김준석";
+        authService.signUp(member, getInfoRequest());
+
+        Member staff = createMember("222222", Role.CENTER_STAFF);
+
+        // when
+        List<MemberSearchInfoResponse> responses = memberService.searchMemberInfo(staff, keyword);
+
+        // then
+        assertEquals(1, responses.size());
+        assertEquals(member.getId(), responses.get(0).getMemberId());
+    }
+
+    @Test
+    @DisplayName("운영진용 유저 검색 테스트 - 여러명인 경우")
+    @Transactional
+    public void searchMembersInfo() {
+        // given
+        String keyword = "벡스/김준석";
+
+        authService.signUp(member, getInfoRequest());
+
+        Member anotherMember = createMember("222222", Role.CAMPUS_STAFF);
+        authService.signUp(anotherMember, getInfoRequest());
+
+        Member staff = createMember("333333", Role.CENTER_STAFF);
+
+        // when
+        List<MemberSearchInfoResponse> responses = memberService.searchMemberInfo(staff, keyword);
+
+        // then
+        assertEquals(2, responses.size());
+    }
+
+    @Test
+    @DisplayName("운영진용 유저 검색 테스트 - 상위 운영진 미조회")
+    @Transactional
+    public void searchMembersInfoByLowRole() {
+        // given
+        String keyword = "벡스/김준석";
+
+        authService.signUp(member, getInfoRequest());
+
+        Member anotherMember = createMember("222222", Role.TOTAL_STAFF);
+        authService.signUp(anotherMember, getInfoRequest());
+
+        Member staff = createMember("333333", Role.CENTER_STAFF);
+
+        // when
+        List<MemberSearchInfoResponse> responses = memberService.searchMemberInfo(staff, keyword);
+
+        // then
+        assertEquals(1, responses.size());
+    }
+
+
 }

--- a/src/test/java/com/umc/networkingService/support/ServiceIntegrationTestConfig.java
+++ b/src/test/java/com/umc/networkingService/support/ServiceIntegrationTestConfig.java
@@ -72,7 +72,7 @@ public abstract class ServiceIntegrationTestConfig {
         );
     }
 
-    protected MemberSignUpRequest getInfoRequest(Member nowMember) {
+    protected MemberSignUpRequest getInfoRequest() {
         return MemberSignUpRequest.builder()
                 .name("김준석")
                 .nickname("벡스")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#27/staff-member-api -> develop

### 변경 사항

**1. 운영진용 멤버 관련 API 구현**
- 회원 정보 수정 API : 본인과 같거나 높은 등급의 운영진 정보는 수정할 수 없도록 제한
- 회원 검색 API : 검색어({닉네임/이름})에 응답하는 회원 정보를 반환하되, 동일한 닉네임/이름을 가진 다른 회원을 구분하기 위해 학교 이름도 추가로 반환. 본인과 같거나 높은 등급의 운영진은 검색 결과에서 제외

**2. 문서 업데이트**
- 스웨거 문서 업데이트
- 노션 문서 업데이트

**3. 보안 설정 수정**

**[문제]**  : 로그인 사용자 정보를 사용하지 않는 API에서도 accessToken 없이 실행 가능
**[원인]** : securityConfig 파일에서는 역할(role)에 따른 접근 권한만 부여
**[해결]** : 스웨거 관련 엔드포인트와 소셜 로그인 엔드포인트는 권한 해제하고, 나머지 모든 API에는 권한 설정 적용

### 테스트 결과
1. StaffControllerTest 결과 - 2개
  ![image](https://github.com/Team-UMC/UMC-Server/assets/30834810/aacf8907-aea6-4ba3-8234-d994df2a91da)

2. MemberServiceIntegrationTest 결과 - 14개(추가 3개)
  ![image](https://github.com/Team-UMC/UMC-Server/assets/30834810/e0489ed0-3aa4-4d71-b058-3254bbf7dd94)
