### PR TITLE
[FIX] 스케줄 레포지토리 findScheduleByYearAndMonth 인자 수정

### DIFF
--- a/src/main/java/com/umc/networkingService/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/repository/ScheduleRepository.java
@@ -13,7 +13,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, UUID> {
 
     @Query(value = "SELECT s FROM Schedule s WHERE DATE_FORMAT(s.startDateTime, '%Y-%m') <= DATE_FORMAT(:date, '%Y-%m') AND DATE_FORMAT(:date, '%Y-%m') <= DATE_FORMAT(s.endDateTime, '%Y-%m')")
     List<Schedule> findSchedulesByYearAndMonth (
-            @Param("yearMonth") LocalDate date
+            @Param("date") LocalDate date
     );
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[v] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#53/Scheduel -> develop

### 변경 사항
- ScheduleRepository의 findSchedulesByYearAndMonth()에서 @Param() 내부 인자를 수정했습니다.

### 테스트 결과

