### PR TITLE
[FEAT] 마스코트 데이터 설정 및 서버 시간 수정

### DIFF
--- a/src/main/java/com/umc/networkingService/NetworkingServiceApplication.java
+++ b/src/main/java/com/umc/networkingService/NetworkingServiceApplication.java
@@ -4,11 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class NetworkingServiceApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(NetworkingServiceApplication.class, args);
 	}
 

--- a/src/main/java/com/umc/networkingService/config/initial/DataLoader.java
+++ b/src/main/java/com/umc/networkingService/config/initial/DataLoader.java
@@ -64,7 +64,7 @@ public class DataLoader implements ApplicationListener<ContextRefreshedEvent> {
                         .startLevel(mascot.getStartLevel())
                         .endLevel(mascot.getEndLevel())
                         .type(mascot.getMascotType())
-                        .dialogue(mascot.getDialogue())
+                        .dialogues(mascot.getDialogue())
                         .image(mascot.getImageUrl())
                         .build())
                 .forEach(mascotRepository::save);

--- a/src/main/java/com/umc/networkingService/config/initial/MascotInfo.java
+++ b/src/main/java/com/umc/networkingService/config/initial/MascotInfo.java
@@ -4,25 +4,27 @@ import com.umc.networkingService.domain.mascot.entity.MascotType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @RequiredArgsConstructor
 public enum MascotInfo {
-    U_STEP1(1, 10, MascotType.UU, "나 머리가 간지러워", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV1.png"),
-    U_STEP2(11, 20, MascotType.UU, "나 말하고 싶어", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV2.png"),
-    U_STEP3(21, 30, MascotType.UU, "입 생겼다~", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV3.png"),
-    U_STEP4(31, 40, MascotType.UU, "", ""),
-    M_STEP1(1, 10, MascotType.MM, "나는 왜 귀가 없을까", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV1.png"),
-    M_STEP2(11, 20, MascotType.MM, "나 볼이 간지러워", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV2.png"),
-    M_STEP3(21, 30, MascotType.MM, "나는 고양이다~", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV3.png"),
-    M_STEP4(31, 40, MascotType.MM, "", ""),
-    C_STEP1(1, 10, MascotType.CC, "...", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV1.png"),
-    C_STEP2(11, 20, MascotType.CC, "머리 자랐다...", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV2.png"),
-    C_STEP3(21, 30, MascotType.CC, "입 생겼다...", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV3.png"),
-    C_STEP4(31, 40, MascotType.CC, "", ""),
+    U_STEP1(1, 10, MascotType.UU, List.of("나 머리가 간지러워", "반가워!!"), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV1.png"),
+    U_STEP2(11, 20, MascotType.UU, List.of("나는 씩씩한 입을 갖고 싶어", "곧 다음 단계야"), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV2.png"),
+    U_STEP3(21, 30, MascotType.UU, List.of("나 멋있지?", "조금만 더 노력하면 마지막 단계야"), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV3.png"),
+    U_STEP4(31, 40, MascotType.UU, List.of("우리 학교 짱짱", "날 키워줘서 고마워"), ""),
+    M_STEP1(1, 10, MascotType.MM, List.of("저는 왜 귀가 없을까요", "안녕하세요"), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV1.png"),
+    M_STEP2(11, 20, MascotType.MM, List.of("저 볼이 간지러워요", "조금만 더 노력하면 다음 단계에요"), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV2.png"),
+    M_STEP3(21, 30, MascotType.MM, List.of("저는 고양이이에요 야옹~", "곧 마지막 단계에요"), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV3.png"),
+    M_STEP4(31, 40, MascotType.MM, List.of("우리 학교 짱이에요", "절 키워줘서 고마워요"), ""),
+    C_STEP1(1, 10, MascotType.CC, List.of("...", "안녕..."), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV1.png"),
+    C_STEP2(11, 20, MascotType.CC, List.of("머리 자랐다...", "조금만 더 노력해줘..."), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV2.png"),
+    C_STEP3(21, 30, MascotType.CC, List.of("입 생겼다...", "곧 마지막..."), "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV3.png"),
+    C_STEP4(31, 40, MascotType.CC, List.of("우리 학교... 짱...", "키워줘서... 고마워..."), ""),
     ;
     private final int startLevel;
     private final int endLevel;
     private final MascotType mascotType;
-    private final String dialogue;
+    private final List<String> dialogue;
     private final String imageUrl;
 }

--- a/src/main/java/com/umc/networkingService/config/initial/MascotInfo.java
+++ b/src/main/java/com/umc/networkingService/config/initial/MascotInfo.java
@@ -1,0 +1,28 @@
+package com.umc.networkingService.config.initial;
+
+import com.umc.networkingService.domain.mascot.entity.MascotType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MascotInfo {
+    U_STEP1(1, 10, MascotType.UU, "나 머리가 간지러워", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV1.png"),
+    U_STEP2(11, 20, MascotType.UU, "나 말하고 싶어", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV2.png"),
+    U_STEP3(21, 30, MascotType.UU, "입 생겼다~", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/U_LV3.png"),
+    U_STEP4(31, 40, MascotType.UU, "", ""),
+    M_STEP1(1, 10, MascotType.MM, "나는 왜 귀가 없을까", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV1.png"),
+    M_STEP2(11, 20, MascotType.MM, "나 볼이 간지러워", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV2.png"),
+    M_STEP3(21, 30, MascotType.MM, "나는 고양이다~", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/M_LV3.png"),
+    M_STEP4(31, 40, MascotType.MM, "", ""),
+    C_STEP1(1, 10, MascotType.CC, "...", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV1.png"),
+    C_STEP2(11, 20, MascotType.CC, "머리 자랐다...", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV2.png"),
+    C_STEP3(21, 30, MascotType.CC, "입 생겼다...", "https://umc-service-bucket.s3.ap-northeast-2.amazonaws.com/mascot/C_LV3.png"),
+    C_STEP4(31, 40, MascotType.CC, "", ""),
+    ;
+    private final int startLevel;
+    private final int endLevel;
+    private final MascotType mascotType;
+    private final String dialogue;
+    private final String imageUrl;
+}

--- a/src/main/java/com/umc/networkingService/config/initial/UniversityInfo.java
+++ b/src/main/java/com/umc/networkingService/config/initial/UniversityInfo.java
@@ -1,43 +1,45 @@
 package com.umc.networkingService.config.initial;
 
+import com.umc.networkingService.domain.mascot.entity.MascotType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum UniversityInfo {
-    GACHON_UNIV("가천대학교", "", ""),
-    CATHOLIC_UNIV("가톨릭대학교", "", ""),
-    KYONGGI_UNIV("경기대학교", "", ""),
-    GYEONGSANG_NATIONAL_UNIV("경상국립대학교", "", ""),
-    KYUNGHEE_UNIV("경희대학교", "", ""),
-    KWANGWOON_UNIV("광운대학교", "", ""),
-    DUKSUNG_WOMENS_UNIV("덕성여자대학교", "", ""),
-    DONGGUK_UNIV("동국대학교", "", ""),
-    DONGDUK_WOMENS_UNIV("동덕여자대학교", "", ""),
-    MYONGJI_UNIV("명지대학교", "", ""),
-    PUKYONG_UNIV("부경대학교", "", ""),
-    SANGMYUNG_UNIV("상명대학교", "", ""),
-    SEOKYEONG_UNIV("서경대학교", "", ""),
-    SEOUL_WOMENS_UNIV("서울여자대학교", "", ""),
-    SUNGSHIN_WOMENS_UNIV("성신여자대학", "", ""),
-    SOOKMYUNG_WOMENS_UNIV("숙명여자대학교", "", ""),
-    SOONGSIL_UNIV("숭실대학교", "", ""),
-    AJOU_UNIV("아주대학교", "", ""),
-    ULSAN_UNIV("울산대학교", "", ""),
-    EWHA_WOMANS_UNIV("이화여자대학교", "", ""),
-    INHA_UNIV("인하대학교", "", ""),
-    CHUNGANG_UNIV("중앙대학교", "", ""),
-    KOREA_TECHNOLOGY_AND_EDUCATION_UNIV("한국공과대학교", "", ""),
-    HANKUK_FOREIGN_STUDIES_UNIV("한국외국어대학교", "", ""),
-    KOREA_AEROSPACE_UNIV("한국항공대학교", "", ""),
-    HANSUNG_UNIV("한성학교", "", ""),
-    HANYANG_UNIV("한양대학교", "", ""),
-    HANYANG_ERICA_UNIV("한양대학교 ERICA", "", ""),
-    HONGIK_UNIV("홍익대학교", "", "")
+    GACHON_UNIV("가천대학교", "", "", MascotType.UU),
+    CATHOLIC_UNIV("가톨릭대학교", "", "", MascotType.MM),
+    KYONGGI_UNIV("경기대학교", "", "", MascotType.CC),
+    GYEONGSANG_NATIONAL_UNIV("경상국립대학교", "", "", MascotType.UU),
+    KYUNGHEE_UNIV("경희대학교", "", "", MascotType.MM),
+    KWANGWOON_UNIV("광운대학교", "", "", MascotType.CC),
+    DUKSUNG_WOMENS_UNIV("덕성여자대학교", "", "", MascotType.UU),
+    DONGGUK_UNIV("동국대학교", "", "", MascotType.MM),
+    DONGDUK_WOMENS_UNIV("동덕여자대학교", "", "", MascotType.CC),
+    MYONGJI_UNIV("명지대학교", "", "", MascotType.UU),
+    PUKYONG_UNIV("부경대학교", "", "", MascotType.MM),
+    SANGMYUNG_UNIV("상명대학교", "", "", MascotType.CC),
+    SEOKYEONG_UNIV("서경대학교", "", "", MascotType.UU),
+    SEOUL_WOMENS_UNIV("서울여자대학교", "", "", MascotType.MM),
+    SUNGSHIN_WOMENS_UNIV("성신여자대학", "", "", MascotType.CC),
+    SOOKMYUNG_WOMENS_UNIV("숙명여자대학교", "", "", MascotType.UU),
+    SOONGSIL_UNIV("숭실대학교", "", "", MascotType.MM),
+    AJOU_UNIV("아주대학교", "", "", MascotType.CC),
+    ULSAN_UNIV("울산대학교", "", "", MascotType.UU),
+    EWHA_WOMANS_UNIV("이화여자대학교", "", "", MascotType.MM),
+    INHA_UNIV("인하대학교", "", "", MascotType.CC),
+    CHUNGANG_UNIV("중앙대학교", "", "", MascotType.UU),
+    KOREA_TECHNOLOGY_AND_EDUCATION_UNIV("한국공과대학교", "", "", MascotType.MM),
+    HANKUK_FOREIGN_STUDIES_UNIV("한국외국어대학교", "", "", MascotType.CC),
+    KOREA_AEROSPACE_UNIV("한국항공대학교", "", "", MascotType.UU),
+    HANSUNG_UNIV("한성학교", "", "", MascotType.MM),
+    HANYANG_UNIV("한양대학교", "", "", MascotType.CC),
+    HANYANG_ERICA_UNIV("한양대학교 ERICA", "", "", MascotType.UU),
+    HONGIK_UNIV("홍익대학교", "", "", MascotType.MM)
     ;
 
     private final String name;
     private final String universityLogo;
     private final String semesterLogo;
+    private final MascotType mascotType;
 }

--- a/src/main/java/com/umc/networkingService/domain/mascot/entity/Mascot.java
+++ b/src/main/java/com/umc/networkingService/domain/mascot/entity/Mascot.java
@@ -9,6 +9,9 @@ import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 @Getter
@@ -34,7 +37,17 @@ public class Mascot extends BaseEntity {
     @Column(nullable = false)
     private MascotType type;
 
-    private String dialogue;
+    @ElementCollection
+    private List<String> dialogues;
 
     private String image;
+
+    // 대사 2개 랜덤 추출 함수
+    public List<String> getRandomDialogues() {
+        List<String> dialogues = this.getDialogues();
+
+        // 순서 섞어서 랜덤 2개 추출
+        Collections.shuffle(dialogues, new Random());
+        return dialogues.stream().limit(2).toList();
+    }
 }

--- a/src/main/java/com/umc/networkingService/domain/mascot/repository/MascotRepository.java
+++ b/src/main/java/com/umc/networkingService/domain/mascot/repository/MascotRepository.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 
 public interface MascotRepository  extends JpaRepository<Mascot, UUID> {
     Optional<Mascot> findByStartLevelAndType(int startLevel, MascotType type);
-
+    boolean existsByStartLevelAndType(int startLevel, MascotType type);
 }

--- a/src/main/java/com/umc/networkingService/domain/university/dto/response/UniversityResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/university/dto/response/UniversityResponse.java
@@ -99,7 +99,7 @@ public class UniversityResponse {
         Long point;
         Integer rank;
         String mascotImage;
-        String mascotDialog;
+        List<String> mascotDialog;
         String universityImage;
 
         public static joinUniversityMascot setRank(joinUniversityMascot universityMascot, Integer rank) {

--- a/src/main/java/com/umc/networkingService/domain/university/mapper/UniversityMapper.java
+++ b/src/main/java/com/umc/networkingService/domain/university/mapper/UniversityMapper.java
@@ -68,7 +68,7 @@ public class UniversityMapper {
             University university, Mascot mascot
     ){
         return UniversityResponse.joinUniversityMascot.builder()
-                .mascotDialog(mascot.getDialogue())
+                .mascotDialog(mascot.getRandomDialogues())
                 .mascotImage(mascot.getImage())
                 .level(university.getCurrentLevel())
                 .point(university.getTotalPoint())

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,3 +17,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,3 +17,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul

--- a/src/test/java/com/umc/networkingService/domain/university/service/UniversityServiceIntegrationTest.java
+++ b/src/test/java/com/umc/networkingService/domain/university/service/UniversityServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.umc.networkingService.domain.university.service;
 
-import com.umc.networkingService.domain.mascot.entity.Mascot;
 import com.umc.networkingService.domain.mascot.repository.MascotRepository;
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.member.entity.PointType;
@@ -19,9 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -119,12 +115,12 @@ public class UniversityServiceIntegrationTest extends ServiceIntegrationTestConf
     @Transactional
     public void joinUniversityMascotTest_Success() {
         //given
-        System.out.println(member.getUniversity().getMascot().getDialogue());
+        System.out.println(member.getUniversity().getMascot().getDialogues());
         //when
         UniversityResponse.joinUniversityMascot universityMascot = universityService.joinUniversityMascot(member);
 
         //then
-        assertThat(universityMascot.getMascotDialog()).isEqualTo(mascot.getDialogue());
+        assertThat(universityMascot.getMascotDialog()).isEqualTo(mascot.getDialogues());
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#70/mascot-data -> develop

### 변경 사항
1. 마스코트 내 dialogue -> dialogues변경
    - 여러개의 대사 저장하도록 변경
    - 마스코트 조회 시 랜덤으로 2개의 대사가 조회되도록 변경
2. 마스코트 데이터 설정
3. 서버 시간 한국 시간과 동기화 설정

### 테스트 결과
1. 마스코트 데이터 정상적으로 생성
![image](https://github.com/Team-UMC/UMC-Server/assets/30834810/1d5cd2cf-4121-44ab-94a3-7f48fa623f31)
