### PR TITLE
[FEAT] 스케줄 더미 데이터 및 스케줄 조회 API 수정

### DIFF
--- a/src/main/java/com/umc/networkingService/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/controller/ScheduleController.java
@@ -31,9 +31,10 @@ public class ScheduleController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공")
     })
-    public BaseResponse<ScheduleInfoSummaryLists> getScheduleLists(@RequestParam LocalDate date) {
+    public BaseResponse<ScheduleInfoSummaryLists> getScheduleLists(@CurrentMember Member member,
+                                                                   @RequestParam LocalDate date) {
 
-        return BaseResponse.onSuccess((scheduleService.getScheduleLists(date)));
+        return BaseResponse.onSuccess((scheduleService.getScheduleLists(member, date)));
     }
 
     @Operation(summary = "일정 조회(상세조회)", description = "홈화면의 달력에서 일정을 상세조회하는 API입니다.")
@@ -55,8 +56,9 @@ public class ScheduleController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공")
     })
-    public BaseResponse<ScheduleInfoSummariesInCalendar> getSchedule(@RequestParam LocalDate date) {
+    public BaseResponse<ScheduleInfoSummariesInCalendar> getSchedule(@CurrentMember Member member,
+                                                                     @RequestParam LocalDate date) {
 
-        return BaseResponse.onSuccess(scheduleService.getCalendarByMonth(date));
+        return BaseResponse.onSuccess(scheduleService.getCalendarByMonth(member, date));
     }
 }

--- a/src/main/java/com/umc/networkingService/domain/schedule/controller/StaffScheduleController.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/controller/StaffScheduleController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "운영진 스케줄 API", description = "운영진 스케줄 관련 API")
+@Tag(name = "운영진 일정 API", description = "운영진 일정 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/staff/schedules")

--- a/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleService.java
@@ -12,11 +12,11 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public interface ScheduleService {
-    ScheduleInfoSummariesInCalendar getCalendarByMonth(LocalDate date);
+    ScheduleInfoSummariesInCalendar getCalendarByMonth(Member member, LocalDate date);
     ScheduleId createSchedule(Member member, CreateSchedule request);
     ScheduleId updateSchedule(Member member, UUID scheduleId, UpdateSchedule request);
     ScheduleId deleteSchedule(Member member, UUID scheduleId);
-    ScheduleInfoSummaryLists getScheduleLists(LocalDate date);
+    ScheduleInfoSummaryLists getScheduleLists(Member member, LocalDate date);
     ScheduleDetail getScheduleDetail(Member member, UUID scheduleId);
 
 }

--- a/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleService.java
@@ -15,11 +15,8 @@ public interface ScheduleService {
     ScheduleInfoSummariesInCalendar getCalendarByMonth(LocalDate date);
     ScheduleId createSchedule(Member member, CreateSchedule request);
     ScheduleId updateSchedule(Member member, UUID scheduleId, UpdateSchedule request);
-
     ScheduleId deleteSchedule(Member member, UUID scheduleId);
-
     ScheduleInfoSummaryLists getScheduleLists(LocalDate date);
-
     ScheduleDetail getScheduleDetail(Member member, UUID scheduleId);
 
 }

--- a/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleServiceImpl.java
@@ -30,7 +30,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 
         return scheduleMapper.toScheduleInfoSummariesInCalendar(
                 scheduleRepository.findSchedulesByYearAndMonth(date).stream()
-                        .map(schedule -> scheduleMapper.toScheduleInfoSummaryInCalendar(schedule))
+                        .map(scheduleMapper::toScheduleInfoSummaryInCalendar)
                         .toList());
     }
 
@@ -51,13 +51,14 @@ public class ScheduleServiceImpl implements ScheduleService {
     private List<ScheduleInfoSummary> filterSchedulesByHostType(List<Schedule> schedules, HostType hostType) {
         return schedules.stream()
                 .filter(schedule -> schedule.getHostType().equals(hostType))
-                .map(schedule -> scheduleMapper.toScheduleInfoSummary(schedule))
+                .map(scheduleMapper::toScheduleInfoSummary)
                 .toList();
     }
 
     @Override
     public ScheduleDetail getScheduleDetail(Member member, UUID scheduleId) {
-        Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new RestApiException(ScheduleErrorCode.EMPTY_SCHEDULE));
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new RestApiException(ScheduleErrorCode.EMPTY_SCHEDULE));
 
         return scheduleMapper.toScheduleDetail(schedule);
     }

--- a/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/schedule/service/ScheduleServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.networkingService.domain.schedule.service;
 
 import com.umc.networkingService.domain.board.entity.HostType;
 import com.umc.networkingService.domain.member.entity.Member;
+import com.umc.networkingService.domain.member.service.MemberService;
 import com.umc.networkingService.domain.schedule.dto.request.ScheduleRequest.CreateSchedule;
 import com.umc.networkingService.domain.schedule.dto.request.ScheduleRequest.UpdateSchedule;
 import com.umc.networkingService.domain.schedule.dto.response.ScheduleResponse.*;
@@ -25,19 +26,29 @@ public class ScheduleServiceImpl implements ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final ScheduleMapper scheduleMapper;
 
+    private final MemberService memberService;
+
     @Override
-    public ScheduleInfoSummariesInCalendar getCalendarByMonth(LocalDate date) {
+    public ScheduleInfoSummariesInCalendar getCalendarByMonth(Member loginMember, LocalDate date) {
+
+        Member member = memberService.loadEntity(loginMember.getId());
+
+        List<Schedule> schedulesLists = validateSchedules(member,
+                scheduleRepository.findSchedulesByYearAndMonth(date));
 
         return scheduleMapper.toScheduleInfoSummariesInCalendar(
-                scheduleRepository.findSchedulesByYearAndMonth(date).stream()
+                schedulesLists.stream()
                         .map(scheduleMapper::toScheduleInfoSummaryInCalendar)
                         .toList());
     }
 
     @Override
-    public ScheduleInfoSummaryLists getScheduleLists(LocalDate date) {
+    public ScheduleInfoSummaryLists getScheduleLists(Member loginMember, LocalDate date) {
 
-        List<Schedule> schedulesLists = scheduleRepository.findSchedulesByYearAndMonth(date);
+        Member member = memberService.loadEntity(loginMember.getId());
+
+        List<Schedule> schedulesLists = validateSchedules(member,
+                scheduleRepository.findSchedulesByYearAndMonth(date));
 
         List<ScheduleInfoSummary> campusSchedules = filterSchedulesByHostType(schedulesLists, HostType.CAMPUS);
 
@@ -53,6 +64,28 @@ public class ScheduleServiceImpl implements ScheduleService {
                 .filter(schedule -> schedule.getHostType().equals(hostType))
                 .map(scheduleMapper::toScheduleInfoSummary)
                 .toList();
+    }
+
+    private List<Schedule> validateSchedules(Member member, List<Schedule> schedules) {
+        return schedules.stream()
+                .filter(schedule -> validateScheduleUniversityAndBranch(member, schedule))
+                .filter(schedule -> validateScheduleSemester(member, schedule))
+                .toList();
+    }
+
+    private boolean validateScheduleUniversityAndBranch(Member member, Schedule schedule) {
+        if (schedule.getHostType().equals(HostType.CENTER))
+            return true;
+        if (schedule.getHostType().equals(HostType.BRANCH)
+                && member.getBranch() == schedule.getWriter().getBranch())
+            return true;
+        return schedule.getHostType().equals(HostType.CAMPUS)
+                && member.getUniversity() == schedule.getWriter().getUniversity();
+    }
+
+    private boolean validateScheduleSemester(Member member, Schedule schedule) {
+        return member.getSemesters().stream()
+                .anyMatch(memberSemester -> schedule.getSemesterPermission().contains(memberSemester));
     }
 
     @Override

--- a/src/main/java/com/umc/networkingService/domain/test/controller/TestController.java
+++ b/src/main/java/com/umc/networkingService/domain/test/controller/TestController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class TestController {
     private final TestService testService;
 
-    @Operation(summary = "dummy Board 생성 API", description = "보드 더미데이터를 생성합니다. 회원 가입 완료 후 사용해주세요!")
+    @Operation(summary = "dummy Board, Schedule 생성 API", description = "보드, 스케줄 더미데이터를 생성합니다. 회원 가입 완료 후 사용해주세요!")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공")
     })


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [X] 버그 수정

### 반영 브랜치
feature/#86/schedule-dummty-data -> develop

### 변경 사항
1. 더미데이터 추가 API에 스케줄 더미 데이터 추가
2. 스케줄 조회 API 수정
    - 조회 시 로그인 유저 학교와 지부에 속하는 스케줄만 조회
    - 조회 시 로그인 유저의 기수가 포함된 스케줄만 조회
