### PR TITLE
[FEAT] web용 ìTIL 일별 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/networkingService/domain/todayILearned/controller/TodayILearnedController.java
+++ b/src/main/java/com/umc/networkingService/domain/todayILearned/controller/TodayILearnedController.java
@@ -8,6 +8,7 @@ import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearned
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedId;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedInfos;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedDetail;
+import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedWebInfos;
 import com.umc.networkingService.domain.todayILearned.service.TodayILearnedService;
 import com.umc.networkingService.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,6 +73,19 @@ public class TodayILearnedController {
                                                                   @RequestParam(value = "date") String date) {
 
         return BaseResponse.onSuccess(todayILearnedService.getTodayILearnedInfos(member, date));
+    }
+
+    @Operation(summary = "Today I Learned 조회(일별) - Web", description = "웹용 TIL(일별)을 조회하는 API입니다.")
+    @GetMapping("/web")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공")
+    })
+    @Parameters(value = {
+            @Parameter(name="date", description = "현재 날짜를 2024-02-08 형식으로 전달해 주세요.")
+    })
+    public BaseResponse<TodayILearnedWebInfos> getTodayILearnedWebInfos(@CurrentMember Member member,
+                                                                        @RequestParam(value = "date") String date) {
+        return BaseResponse.onSuccess(todayILearnedService.getTodayILearnedWebInfos(member, date));
     }
 
 

--- a/src/main/java/com/umc/networkingService/domain/todayILearned/dto/response/TodayILearnedResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/todayILearned/dto/response/TodayILearnedResponse.java
@@ -51,6 +51,26 @@ public class TodayILearnedResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class TodayILearnedWebInfo {
+        private UUID todayILearnedId;
+        private String title;
+        private String subTitle;
+        private String content;
+        private Part part;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TodayILearnedWebInfos {
+        private List<TodayILearnedWebInfo> todayILearnedInfos;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class TodayILearnedDetail {
         private UUID todayILearnedId;
         private String title;

--- a/src/main/java/com/umc/networkingService/domain/todayILearned/mapper/TodayILearnedMapper.java
+++ b/src/main/java/com/umc/networkingService/domain/todayILearned/mapper/TodayILearnedMapper.java
@@ -2,10 +2,14 @@ package com.umc.networkingService.domain.todayILearned.mapper;
 
 import com.umc.networkingService.domain.member.entity.Member;
 import com.umc.networkingService.domain.todayILearned.dto.requeest.TodayILearnedRequest.TodayILearnedCreate;
+import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedId;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedInfo;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedInfos;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedDetail;
+import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedWebInfos;
+import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedWebInfo;
+
 import com.umc.networkingService.domain.todayILearned.entity.TodayILearned;
 import org.springframework.stereotype.Component;
 
@@ -43,6 +47,16 @@ public class TodayILearnedMapper {
     public TodayILearnedInfos toTodayILearnedInfos(List<TodayILearnedInfo> todayILearnedInfos) {
         return TodayILearnedInfos.builder()
                 .todayILearnedInfos(todayILearnedInfos)
+                .build();
+    }
+
+    public TodayILearnedWebInfo toTodayILearnedWebInfo(TodayILearned todayILearned) {
+        return TodayILearnedWebInfo.builder()
+                .todayILearnedId(todayILearned.getId())
+                .title(todayILearned.getTitle())
+                .subTitle(todayILearned.getSubtitle())
+                .content(todayILearned.getContent())
+                .part(todayILearned.getPart())
                 .build();
     }
 

--- a/src/main/java/com/umc/networkingService/domain/todayILearned/service/TodayILearnedService.java
+++ b/src/main/java/com/umc/networkingService/domain/todayILearned/service/TodayILearnedService.java
@@ -7,6 +7,7 @@ import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearned
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedId;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedInfos;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedDetail;
+import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedWebInfos;
 import com.umc.networkingService.domain.todayILearned.entity.TodayILearned;
 import com.umc.networkingService.global.common.base.EntityLoader;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public interface TodayILearnedService extends EntityLoader<TodayILearned, UUID> {
     TodayILearnedResponse.TodayILearnedCreate createTodayILearned(Member member, List<MultipartFile> files, TodayILearnedCreate request);
     TodayILearnedInfos getTodayILearnedInfos(Member member, String date);
+    TodayILearnedWebInfos getTodayILearnedWebInfos(Member member, String date);
     TodayILearnedId updateTodayILearned(Member member, UUID todayILearnedId, List<MultipartFile> files, TodayILearnedUpdate request);
     TodayILearnedId deleteTodayILearned(Member member, UUID todayILearnedId);
     TodayILearnedDetail getTodayILearnedDetail(Member member, UUID todayILearnedId);

--- a/src/main/java/com/umc/networkingService/domain/todayILearned/service/TodayILearnedServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/todayILearned/service/TodayILearnedServiceImpl.java
@@ -7,6 +7,7 @@ import com.umc.networkingService.domain.todayILearned.dto.requeest.TodayILearned
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedId;
 import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedInfos;
+import com.umc.networkingService.domain.todayILearned.dto.response.TodayILearnedResponse.TodayILearnedWebInfos;
 import com.umc.networkingService.domain.todayILearned.entity.TodayILearned;
 import com.umc.networkingService.domain.todayILearned.entity.TodayILearnedFile;
 import com.umc.networkingService.domain.todayILearned.mapper.TodayILearnedMapper;
@@ -64,6 +65,18 @@ public class TodayILearnedServiceImpl implements TodayILearnedService {
                 todayILearnedRepository.findTodayILearnedByWriterAndCreateDate(member, date)
                         .stream()
                         .map(todayILearnedMapper::toTodayILearnedInfo)
+                        .toList());
+    }
+
+    @Override
+    public TodayILearnedWebInfos getTodayILearnedWebInfos(Member member, String stringDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate date = LocalDate.parse(stringDate,formatter);
+
+        return new TodayILearnedWebInfos(
+                todayILearnedRepository.findTodayILearnedByWriterAndCreateDate(member, date)
+                        .stream()
+                        .map(todayILearnedMapper::toTodayILearnedWebInfo)
                         .toList());
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가

### 반영 브랜치
feature/#88/web-til-api -> develop

### 변경 사항
1. 웹용 TIL 일별 조회 API 구현
    - 앱과 다르게 TIL content 정보도 같이 보내도록 구현
    - 추후 삭제하고 앱용과 통합하여 할 예

### 테스트 결과
![image](https://github.com/Team-UMC/UMC-Server/assets/30834810/eb5b24c4-fb3d-4fc8-b6a9-b1552b02e8b1)
