### PR TITLE
[FEAT] 홈화면 핀고정된 공지 조회 api

### DIFF
--- a/src/main/java/com/umc/networkingService/domain/board/controller/BoardController.java
+++ b/src/main/java/com/umc/networkingService/domain/board/controller/BoardController.java
@@ -42,7 +42,7 @@ public class BoardController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
             @ApiResponse(responseCode = "COMMON402", description = "request 요소들의 validation 검증에 실패할 경우 발생"),
-            @ApiResponse(responseCode = "BOARD001", description = "WORKBOOK 게시판과 CENTER, BRANCH를 선택했을 경우 금지된 요청"),
+            @ApiResponse(responseCode = "BOARD001", description = "금지된 요청일 경우 발생"),
             @ApiResponse(responseCode = "BOARD003", description = "게시글을 작성할 권한이 없을 경우 발생"),
             @ApiResponse(responseCode = "FILE001", description = "파일 S3 업로드 실패할 경우 발생")
     })
@@ -61,7 +61,7 @@ public class BoardController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
             @ApiResponse(responseCode = "COMMON402", description = "request 요소들의 validation 검증에 실패할 경우 발생"),
-            @ApiResponse(responseCode = "BOARD001", description = "WORKBOOK 게시판과 CENTER, BRANCH를 선택했을 경우 금지된 요청"),
+            @ApiResponse(responseCode = "BOARD001", description = "금지된 요청일 경우 발생"),
             @ApiResponse(responseCode = "BOARD002", description = "게시글을 찾을 수 없을 경우 발생"),
             @ApiResponse(responseCode = "BOARD003", description = "게시글을 수정할 권한이 없을 경우 발생"),
             @ApiResponse(responseCode = "FILE001", description = "파일 S3 업로드 실패할 경우 발생")
@@ -101,7 +101,8 @@ public class BoardController {
             "board: NOTICE, FREE, WORKBOOK, OB, QUESTION 중 하나의 값을 대문자로 주세요.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공"),
-            @ApiResponse(responseCode = "COMMON405", description = "host, board type이 적절하지 않은 값일 경우 발생")
+            @ApiResponse(responseCode = "COMMON405", description = "host, board type 자체 값이 적절하지 않은 값일 경우 발생"),
+            @ApiResponse(responseCode = "BOARD001", description = "금지된 요청일 경우 발생")
     })
     @Parameters(value = {
             @Parameter(name = "page", description = "page 시작은 0번부터, 내림차순으로 조회됩니다."),
@@ -111,7 +112,7 @@ public class BoardController {
                                                                  @RequestParam(name = "host") HostType hostType,
                                                                  @RequestParam(name = "board") BoardType boardType,
                                                                  @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
-                                                        @Parameter(hidden = true) Pageable pageable) {
+                                                                 @Parameter(hidden = true) Pageable pageable) {
 
         return BaseResponse.onSuccess(boardService.showBoards(member, hostType, boardType, pageable));
     }
@@ -141,7 +142,7 @@ public class BoardController {
     public BaseResponse<BoardResponse.BoardSearchPageInfos> searchBoard(@CurrentMember Member member,
                                                                         @RequestParam(name = "keyword") String keyword,
                                                                         @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
-                                                               @Parameter(hidden = true) Pageable pageable) {
+                                                                        @Parameter(hidden = true) Pageable pageable) {
 
         return BaseResponse.onSuccess(boardService.searchBoard(member, keyword, pageable));
     }
@@ -156,14 +157,14 @@ public class BoardController {
     })
     @GetMapping(value = "/member/app")
     public BaseResponse<MyBoardResponse.MyBoardPageInfos> showBoardsByMemberForApp(@CurrentMember Member member,
-                                                                  @RequestParam(name = "keyword", required = false) String keyword,
-                                                                  @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
-                                                                  @Parameter(hidden = true) Pageable pageable) {
+                                                                                   @RequestParam(name = "keyword", required = false) String keyword,
+                                                                                   @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
+                                                                                   @Parameter(hidden = true) Pageable pageable) {
 
         return BaseResponse.onSuccess(boardService.showBoardsByMemberForApp(member, keyword, pageable));
     }
 
-    @Operation(summary = "[WEB] 내가 쓴 게시글 조회/검색 API", description = "WEB용 내가 쓴 게시글을 조회하거나 검색하는 API입니다.  "+
+    @Operation(summary = "[WEB] 내가 쓴 게시글 조회/검색 API", description = "WEB용 내가 쓴 게시글을 조회하거나 검색하는 API입니다.  " +
             "host: CENTER, BRANCH, CAMPUS 중 하나의 값을 대문자로 주세요.  " +
             "board: NOTICE, FREE, WORKBOOK, OB, QUESTION 중 하나의 값을 대문자로 주세요.")
     @ApiResponses(value = {
@@ -176,13 +177,13 @@ public class BoardController {
     })
     @GetMapping(value = "/member/web")
     public BaseResponse<MyBoardResponse.MyBoardPageInfos> showBoardsByMemberForWeb(@CurrentMember Member member,
-                                                                        @RequestParam(name = "host") HostType hostType,
-                                                                        @RequestParam(name = "board") BoardType boardType,
-                                                                        @RequestParam(name = "keyword", required = false) String keyword,
-                                                                        @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
-                                                                        @Parameter(hidden = true) Pageable pageable) {
+                                                                                   @RequestParam(name = "host") HostType hostType,
+                                                                                   @RequestParam(name = "board") BoardType boardType,
+                                                                                   @RequestParam(name = "keyword", required = false) String keyword,
+                                                                                   @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
+                                                                                   @Parameter(hidden = true) Pageable pageable) {
 
-        return BaseResponse.onSuccess(boardService.showBoardsByMemberForWeb(member, hostType,boardType, keyword, pageable));
+        return BaseResponse.onSuccess(boardService.showBoardsByMemberForWeb(member, hostType, boardType, keyword, pageable));
     }
 
 
@@ -196,13 +197,13 @@ public class BoardController {
     })
     @GetMapping(value = "/member/hearts/app")
     public BaseResponse<MyBoardResponse.MyBoardPageInfos> showMemberBoardHeartForApp(@CurrentMember Member member,
-                                                                     @RequestParam(name = "keyword", required = false) String keyword,
-                                                                     @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
-                                                                     @Parameter(hidden = true) Pageable pageable) {
+                                                                                     @RequestParam(name = "keyword", required = false) String keyword,
+                                                                                     @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
+                                                                                     @Parameter(hidden = true) Pageable pageable) {
         return BaseResponse.onSuccess(boardService.showBoardsByMemberHeartForApp(member, keyword, pageable));
     }
 
-    @Operation(summary = "[WEB] 내가 좋아요한 게시글 조회/검색 API", description = "WEB용 내가 좋아요한 게시글을 조회하거나 검색하는 API입니다.  "+
+    @Operation(summary = "[WEB] 내가 좋아요한 게시글 조회/검색 API", description = "WEB용 내가 좋아요한 게시글을 조회하거나 검색하는 API입니다.  " +
             "host: CENTER, BRANCH, CAMPUS 중 하나의 값을 대문자로 주세요.  " +
             "board: NOTICE, FREE, WORKBOOK, OB, QUESTION 중 하나의 값을 대문자로 주세요.")
     @ApiResponses(value = {
@@ -215,11 +216,11 @@ public class BoardController {
     })
     @GetMapping(value = "/member/hearts/web")
     public BaseResponse<MyBoardResponse.MyBoardPageInfos> showMemberBoardHeartForWeb(@CurrentMember Member member,
-                                                                    @RequestParam(name = "host") HostType hostType,
-                                                                    @RequestParam(name = "board") BoardType boardType,
-                                                                    @RequestParam(name = "keyword", required = false) String keyword,
-                                                                    @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
-                                                                          @Parameter(hidden = true) Pageable pageable) {
+                                                                                     @RequestParam(name = "host") HostType hostType,
+                                                                                     @RequestParam(name = "board") BoardType boardType,
+                                                                                     @RequestParam(name = "keyword", required = false) String keyword,
+                                                                                     @PageableDefault(sort = "created_at", direction = Sort.Direction.DESC)
+                                                                                     @Parameter(hidden = true) Pageable pageable) {
         return BaseResponse.onSuccess(boardService.showBoardsByMemberHeartForWeb(member, hostType, boardType, keyword, pageable));
     }
 

--- a/src/main/java/com/umc/networkingService/domain/board/controller/BoardController.java
+++ b/src/main/java/com/umc/networkingService/domain/board/controller/BoardController.java
@@ -87,6 +87,14 @@ public class BoardController {
         return BaseResponse.onSuccess(boardService.deleteBoard(member, boardId));
     }
 
+    @Operation(summary = "핀고정된 notice 조회 API", description = "핀 고정된 공지 게시글을 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공"),
+    })
+    @GetMapping("/pinned")
+    public BaseResponse<BoardResponse.PinnedNotices> showPinnedNotices(@CurrentMember Member member) {
+        return BaseResponse.onSuccess(boardService.showPinnedNotices(member));
+    }
 
     @Operation(summary = "특정 게시판의 게시글 목록 조회 API", description = "특정 게시판의 게시글 목록을 조회하는 API입니다.  " +
             "host: CENTER, BRANCH, CAMPUS 중 하나의 값을 대문자로 주세요.  " +

--- a/src/main/java/com/umc/networkingService/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/board/dto/response/BoardResponse.java
@@ -119,6 +119,19 @@ public class BoardResponse {
         private LocalDateTime createdAt;
     }
 
+    @Getter
+    @Builder
+    public static class PinnedNotice {
+        private HostType hostType;
+        private String title;
+    }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PinnedNotices {
+        List<PinnedNotice> pinnedNotices = new ArrayList<>();
+    }
 
 }

--- a/src/main/java/com/umc/networkingService/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/umc/networkingService/domain/board/dto/response/BoardResponse.java
@@ -124,6 +124,7 @@ public class BoardResponse {
     public static class PinnedNotice {
         private HostType hostType;
         private String title;
+        private UUID boardId;
     }
 
     @Getter

--- a/src/main/java/com/umc/networkingService/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/umc/networkingService/domain/board/mapper/BoardMapper.java
@@ -36,6 +36,7 @@ public class BoardMapper {
         return BoardResponse.PinnedNotice.builder()
                 .hostType(board.getHostType())
                 .title(board.getTitle())
+                .boardId(board.getId())
                 .build();
     }
     public BoardResponse.PinnedNotices toPinnedNotices(List<Board> boards) {

--- a/src/main/java/com/umc/networkingService/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/umc/networkingService/domain/board/mapper/BoardMapper.java
@@ -32,6 +32,18 @@ public class BoardMapper {
                 .build();
     }
 
+    public BoardResponse.PinnedNotice topinnedNotice(Board board) {
+        return BoardResponse.PinnedNotice.builder()
+                .hostType(board.getHostType())
+                .title(board.getTitle())
+                .build();
+    }
+    public BoardResponse.PinnedNotices toPinnedNotices(List<Board> boards) {
+        List<BoardResponse.PinnedNotice> pinnedNotices = boards.stream().map(this::topinnedNotice).toList();
+        return BoardResponse.PinnedNotices.builder()
+                .pinnedNotices(pinnedNotices)
+                .build();
+    }
     public BoardResponse.BoardPageElement toBoardPageElement(Board board) {
         return BoardResponse.BoardPageElement.builder()
                 .boardId(board.getId())

--- a/src/main/java/com/umc/networkingService/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/umc/networkingService/domain/board/repository/BoardRepositoryCustom.java
@@ -9,9 +9,11 @@ import com.umc.networkingService.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface BoardRepositoryCustom {
-    Page<Board> findAllBoards(Member member, HostType hostType, BoardType boardType, Pageable pageable);
+import java.util.List;
 
+public interface BoardRepositoryCustom {
+    List<Board> findNoticesByMember(Member member);
+    Page<Board> findAllBoards(Member member, HostType hostType, BoardType boardType, Pageable pageable);
     Page<Board> findKeywordBoards(Member member, String keyword, Pageable pageable);
 
     Page<BoardComment> findAllBoardComments(Member member, Board board, Pageable pageable);

--- a/src/main/java/com/umc/networkingService/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -25,7 +25,22 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
     QBoardHeart boardHeart = QBoardHeart.boardHeart;
 
 
-    
+    /*
+    Home 화면에 보여지는 notices 목록 반환
+     */
+    @Override
+    public List<Board> findNoticesByMember(Member member) {
+        return query.selectFrom(board)
+                .where(board.isFixed.eq(true)
+                        .and(
+                                CenterPermission()
+                                        .or(BranchPermission(member))
+                                        .or(CampusPermission(member))
+                        ))
+                .orderBy(board.createdAt.desc())
+                .fetch();
+    }
+
     /*
     HostType, BoardType에 따라 게시글 목록 조회
      */
@@ -304,7 +319,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
         return new PageImpl<>(boards, pageable, query.selectFrom(board).where(eqBoardType(BoardType.NOTICE), predicate).fetch().size());
 
     }
-
 
 
     //hostTYpe과 boardType에 따라 조건 추가

--- a/src/main/java/com/umc/networkingService/domain/board/service/BoardService.java
+++ b/src/main/java/com/umc/networkingService/domain/board/service/BoardService.java
@@ -20,9 +20,11 @@ public interface BoardService extends EntityLoader<Board, UUID> {
     BoardResponse.BoardId updateBoard(Member member, UUID boardId, BoardRequest.BoardUpdateRequest request, List<MultipartFile> files);
 
     BoardResponse.BoardId deleteBoard(Member member, UUID boardId);
+
     BoardResponse.PinnedNotices showPinnedNotices(Member member);
 
     BoardResponse.BoardPageInfos showBoards(Member member, HostType host, BoardType board, Pageable pageable);
+
     BoardResponse.BoardDetail showBoardDetail(Member member, UUID boardId);
 
     BoardResponse.BoardSearchPageInfos searchBoard(Member member, String keyword, Pageable pageable);
@@ -30,8 +32,11 @@ public interface BoardService extends EntityLoader<Board, UUID> {
     BoardResponse.BoardId toggleBoardLike(Member member, UUID boardId);
 
     MyBoardResponse.MyBoardPageInfos showBoardsByMemberForApp(Member member, String keyword, Pageable pageable);
+
     MyBoardResponse.MyBoardPageInfos showBoardsByMemberForWeb(Member member, HostType hostType, BoardType boardType, String keyword, Pageable pageable);
+
     MyBoardResponse.MyBoardPageInfos showBoardsByMemberHeartForApp(Member member, String keyword, Pageable pageable);
+
     MyBoardResponse.MyBoardPageInfos showBoardsByMemberHeartForWeb(Member member, HostType hostType, BoardType boardType, String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/umc/networkingService/domain/board/service/BoardService.java
+++ b/src/main/java/com/umc/networkingService/domain/board/service/BoardService.java
@@ -20,9 +20,9 @@ public interface BoardService extends EntityLoader<Board, UUID> {
     BoardResponse.BoardId updateBoard(Member member, UUID boardId, BoardRequest.BoardUpdateRequest request, List<MultipartFile> files);
 
     BoardResponse.BoardId deleteBoard(Member member, UUID boardId);
+    BoardResponse.PinnedNotices showPinnedNotices(Member member);
 
     BoardResponse.BoardPageInfos showBoards(Member member, HostType host, BoardType board, Pageable pageable);
-
     BoardResponse.BoardDetail showBoardDetail(Member member, UUID boardId);
 
     BoardResponse.BoardSearchPageInfos searchBoard(Member member, String keyword, Pageable pageable);

--- a/src/main/java/com/umc/networkingService/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/board/service/BoardServiceImpl.java
@@ -40,6 +40,13 @@ public class BoardServiceImpl implements BoardService {
 
 
     @Override
+    public BoardResponse.PinnedNotices showPinnedNotices(Member loginMember) {
+        Member member = memberService.loadEntity(loginMember.getId());
+
+        return boardMapper.toPinnedNotices(boardRepository.findNoticesByMember(member));
+
+    }
+    @Override
     public BoardResponse.BoardPageInfos showBoards(Member loginMember, HostType hostType, BoardType boardType, Pageable pageable) {
 
         Member member = memberService.loadEntity(loginMember.getId());
@@ -48,6 +55,7 @@ public class BoardServiceImpl implements BoardService {
 
         return boardMapper.toBoardPageInfos(boardRepository.findAllBoards(member, hostType, boardType, pageable));
     }
+
 
     @Override
     public BoardResponse.BoardSearchPageInfos searchBoard(Member loginMember, String keyword, Pageable pageable) {

--- a/src/main/java/com/umc/networkingService/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/umc/networkingService/domain/board/service/BoardServiceImpl.java
@@ -41,6 +41,7 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public BoardResponse.PinnedNotices showPinnedNotices(Member loginMember) {
+
         Member member = memberService.loadEntity(loginMember.getId());
 
         return boardMapper.toPinnedNotices(boardRepository.findNoticesByMember(member));
@@ -50,8 +51,7 @@ public class BoardServiceImpl implements BoardService {
     public BoardResponse.BoardPageInfos showBoards(Member loginMember, HostType hostType, BoardType boardType, Pageable pageable) {
 
         Member member = memberService.loadEntity(loginMember.getId());
-        //특정 게시글 조회에 HostType ALL 불가능
-        checkHostType(hostType);
+        checkBadRequest(hostType,boardType);
 
         return boardMapper.toBoardPageInfos(boardRepository.findAllBoards(member, hostType, boardType, pageable));
     }
@@ -61,6 +61,7 @@ public class BoardServiceImpl implements BoardService {
     public BoardResponse.BoardSearchPageInfos searchBoard(Member loginMember, String keyword, Pageable pageable) {
 
         Member member = memberService.loadEntity(loginMember.getId());
+
         return boardMapper.toBoardSearchPageInfos(boardRepository.findKeywordBoards(member, keyword, pageable));
 
     }
@@ -140,14 +141,12 @@ public class BoardServiceImpl implements BoardService {
         HostType hostType = HostType.valueOf(request.getHostType());
         BoardType boardType = BoardType.valueOf(request.getBoardType());
 
-        //게시글 작성에 HostType ALL 불가능
-        checkHostType(hostType);
-
-        //boardType과 HostType에 따라 권한 판단
+        //boardType과 HostType에 따라 금지된 요청, 권한 판단
+        checkBadRequest(hostType,boardType);
         List<Semester> semesterPermission = checkPermission(member, hostType, boardType);
 
-        Board board = boardRepository.save(boardMapper.toEntity(member, request, semesterPermission));
 
+        Board board = boardRepository.save(boardMapper.toEntity(member, request, semesterPermission));
         if (files != null)
             boardFileService.uploadBoardFiles(board, files);
 
@@ -163,10 +162,8 @@ public class BoardServiceImpl implements BoardService {
         HostType hostType = HostType.valueOf(request.getHostType());
         BoardType boardType = BoardType.valueOf(request.getBoardType());
 
-        //게시글 수정에 HostType ALL 불가능
-        checkHostType(hostType);
-
-        //boardType과 HostType에 따라 권한 판단
+        //boardType과 HostType에 따라 금지된 요청, 권한 판단
+        checkBadRequest(hostType,boardType);
         List<Semester> semesterPermission = checkPermission(member, hostType, boardType);
 
         //현재 로그인한 member와 writer가 같지 않으면 수정 권한 없음
@@ -211,7 +208,7 @@ public class BoardServiceImpl implements BoardService {
             case OB -> checkPermissionForOBBoard(member, nowSemester);
             case NOTICE -> checkPermissionForNoticeBoard(member, hostType);
             case WORKBOOK -> {
-                checkPermissionForWorkbookBoard(member, hostType);
+                checkPermissionForWorkbookBoard(member);
                 //워크북의 경우 현재 기수만 볼 수 있도록 허용
                 permissionSemesters = List.of(nowSemester);
             }
@@ -222,6 +219,7 @@ public class BoardServiceImpl implements BoardService {
 
     //OB 게시판 권한 확인 함수
     public void checkPermissionForOBBoard(Member member, Semester nowSemester) {
+
         // OB -> Semester의 isActive가 활성화되지 않은 사용자만 가능
         if (member.getRecentSemester().equals(nowSemester))
             throw new RestApiException(BoardErrorCode.NO_AUTHORIZATION_BOARD);
@@ -236,11 +234,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     //workbook 게시판 권한 확인 함수
-    public void checkPermissionForWorkbookBoard(Member member, HostType hostType) {
-
-        //hostType이 CAMPUS가 아닐 경우 금지된 요청
-        if (hostType != HostType.CAMPUS)
-            throw new RestApiException(BoardErrorCode.BAD_REQUEST_BOARD);
+    public void checkPermissionForWorkbookBoard(Member member) {
 
         //CAMPUS && WORKBOOK -> 일반 MEMBER는 작성 불가
         if (member.getRole().getPriority() >= Role.MEMBER.getPriority())
@@ -258,10 +252,15 @@ public class BoardServiceImpl implements BoardService {
 
     }
 
-
-    //게시글 작성, 수정에 HostType ALL 불가능
-    public void checkHostType(HostType hostType) {
+    public void checkBadRequest(HostType hostType, BoardType boardType) {
+        //운영진 공지사항 목록 조회 제외하고는 HostType ALL 불가능
         if (hostType.equals(HostType.ALL))
+            throw new RestApiException(BoardErrorCode.BAD_REQUEST_BOARD);
+        //boardType: workbook, hostType: CAMPUS 가 아닐 경우 금지된 요청
+        if (boardType == BoardType.WORKBOOK && hostType != HostType.CAMPUS)
+            throw new RestApiException(BoardErrorCode.BAD_REQUEST_BOARD);
+        //boardType: OB, hostType: Branch일 경우 금지된 요청
+        if (boardType == BoardType.OB && hostType == HostType.BRANCH)
             throw new RestApiException(BoardErrorCode.BAD_REQUEST_BOARD);
     }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[x] 기능 추가
-[] 기능 삭제
-[x] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#90/pinned-notice -> develop

### 변경 사항
1. 홈화면에 표시되는 핀 고정된 공지사항 list를 반환하는 api를 생성
2. 게시판 조회, 생성, 삭제 시, branch-ob 게시판을 이용하려고 하면 금지된 요청 예외 처리

### 테스트 결과
1.
![image](https://github.com/Team-UMC/UMC-Server/assets/83461362/7fb3afec-9372-4a3d-b018-c05bd4eb335c)

2.
![image](https://github.com/Team-UMC/UMC-Server/assets/83461362/58c1e1f9-9dcc-40ff-98bd-03df634a9622)

